### PR TITLE
[HCNOVEO-697] Incorrect name of the app on the initial backup screen

### DIFF
--- a/mobile/lib/pages/onboarding/permission_onboarding.page.dart
+++ b/mobile/lib/pages/onboarding/permission_onboarding.page.dart
@@ -1,6 +1,7 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/providers/gallery_permission.provider.dart';
@@ -147,6 +148,15 @@ class PermissionOnboardingPage extends HookConsumerWidget {
         buildPermissionDenied()
     };
 
+    Widget buildLogo() {
+      return SvgPicture.asset(
+        context.isDarkTheme
+            ? 'assets/curator-photos-logo-dark.svg'
+            : 'assets/curator-photos-logo-light.svg',
+        height: 52,
+      );
+    }
+
     return Scaffold(
       body: SafeArea(
         child: Center(
@@ -156,10 +166,8 @@ class PermissionOnboardingPage extends HookConsumerWidget {
               crossAxisAlignment: CrossAxisAlignment.center,
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                const ImmichLogo(
-                  heroTag: 'logo',
-                ),
-                const ImmichTitleText(),
+                // const ImmichLogo(heroTag: 'logo'),
+                buildLogo(),
                 AnimatedSwitcher(
                   duration: const Duration(milliseconds: 500),
                   child: Padding(


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
