### PR TITLE
[HCNOVEO-702] Favorite icon is always active in selection mode

### DIFF
--- a/mobile/lib/utils/selection_handlers.dart
+++ b/mobile/lib/utils/selection_handlers.dart
@@ -84,14 +84,23 @@ Future<void> handleFavoriteAssets(
 }) async {
   if (selection.isNotEmpty) {
     shouldFavorite ??= !selection.every((a) => a.isFavorite);
-    await ref
-        .watch(assetProvider.notifier)
-        .toggleFavorite(selection, shouldFavorite);
 
-    final assetOrAssets = selection.length > 1 ? 'assets' : 'asset';
+    // Only operate on assets that actually need a change
+    final List<Asset> targets = shouldFavorite
+        ? selection.where((a) => !a.isFavorite).toList()
+        : selection.where((a) => a.isFavorite).toList();
+
+    if (targets.isEmpty) {
+      return;
+    }
+
+    await ref.watch(assetProvider.notifier).toggleFavorite(targets, shouldFavorite);
+
+    final int affectedCount = targets.length;
+    final assetOrAssets = affectedCount > 1 ? 'assets' : 'asset';
     final toastMessage = shouldFavorite
-        ? 'Added ${selection.length} $assetOrAssets to favorites'
-        : 'Removed ${selection.length} $assetOrAssets from favorites';
+        ? 'Added $affectedCount $assetOrAssets to favorites'
+        : 'Removed $affectedCount $assetOrAssets from favorites';
     if (context.mounted) {
       ImmichToast.show(
         context: context,

--- a/mobile/lib/widgets/asset_grid/control_bottom_app_bar.dart
+++ b/mobile/lib/widgets/asset_grid/control_bottom_app_bar.dart
@@ -157,9 +157,8 @@ class ControlBottomAppBar extends HookConsumerWidget {
           ),
         if (hasRemote && onFavorite != null)
           ControlBoxButton(
-            iconData: unfavorite
-                ? Icons.favorite_border_rounded
-                : Icons.favorite_rounded,
+            iconData:
+                unfavorite ? Icons.favorite_border_rounded : Icons.favorite_rounded,
             label: (unfavorite ? "unfavorite" : "favorite").tr(),
             onPressed: enabled ? onFavorite : null,
           ),

--- a/mobile/lib/widgets/asset_grid/multiselect_grid.dart
+++ b/mobile/lib/widgets/asset_grid/multiselect_grid.dart
@@ -649,10 +649,11 @@ class MultiselectGrid extends HookConsumerWidget {
               onUpload: onUpload,
               enabled: !processing.value,
               selectionAssetState: selectionAssetState.value,
+              // Unfilled heart only when all selected are favorites; otherwise filled
+              unfavorite: selection.value.isNotEmpty && selection.value.every((a) => a.isFavorite),
               onStack: stackEnabled ? onStack : null,
               onEditTime: editEnabled ? onEditTime : null,
               onEditLocation: editEnabled ? onEditLocation : null,
-              unfavorite: unfavorite,
               unarchive: unarchive,
               onToggleLocked: onToggleLockedVisibility,
               onRemoveFromAlbum: onRemoveFromAlbum != null


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)
