### PR TITLE
[HCNOVEO-1606] Backup screen: "Remainder" counter stuck at "1" until screen is refreshed/reopened

### DIFF
--- a/mobile/lib/providers/backup/drift_backup.provider.dart
+++ b/mobile/lib/providers/backup/drift_backup.provider.dart
@@ -10,6 +10,7 @@ import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/extensions/string_extensions.dart';
 import 'package:immich_mobile/infrastructure/repositories/backup.repository.dart';
 import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
+import 'package:immich_mobile/providers/background_sync.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/platform.provider.dart';
 import 'package:immich_mobile/utils/backup_connectivity.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
@@ -440,18 +441,23 @@ class DriftBackupNotifier extends StateNotifier<DriftBackupState> {
           state = state.copyWith(enqueueCount: processed, enqueueTotalCount: total);
         },
         onSuccess: (localAssetId, {bool isDuplicate = false}) {
-          if (!isDuplicate) {
-            state = state.copyWith(
-              backupCount: state.backupCount + 1,
-              remainderCount: state.remainderCount > 0 ? state.remainderCount - 1 : 0,
-            );
-          }
+          state = state.copyWith(
+            backupCount: state.backupCount + 1,
+            remainderCount: state.remainderCount > 0 ? state.remainderCount - 1 : 0,
+          );
           dPrint(() => 'HTTP backup uploaded $localAssetId duplicate=$isDuplicate');
         },
       );
     } finally {
       _httpCancelCompleter = null;
       state = state.copyWith(isHttpBackupActive: false, enqueueCount: 0, enqueueTotalCount: 0);
+      updateSyncing(true);
+      final syncOk = await _ref.read(backgroundSyncProvider).syncRemote();
+      updateSyncing(false);
+      if (!syncOk) {
+        updateError(BackupError.syncFailed);
+      }
+      await getBackupStatus(userId);
     }
   }
 


### PR DESCRIPTION
…refreshed/reopened

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
