### PR TITLE
chore: pin csg-development DHI base images (base-server 202606260459,…

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -56,7 +56,7 @@ services:
 
   redis:
     container_name: immich_redis
-    image: docker.io/valkey/valkey:9@sha256:3b55fbaa0cd93cf0d9d961f405e4dfcc70efe325e2d84da207a0a8e6d8fde4f9
+    image: dhi.io/valkey:8@sha256:b82e8e3b9d78b851f9006ba3e7faf1fb4d48db10dda9b5009f01a2551f4aee64
     command: ["valkey-server", "--protected-mode", "no"]
     healthcheck:
       test: redis-cli ping || exit 1
@@ -64,7 +64,7 @@ services:
 
   database:
     container_name: immich_postgres
-    image: ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0@sha256:bcf63357191b76a916ae5eb93464d65c07511da41e3bf7a8416db519b40b1c23
+    image: ghcr.io/csg-development/postgres:14-vectorchord0.4.3-pgvectors0.2.0@sha256:5b3821e13cb95410607a9984225978df2bdcfbe4bf0a4b210b100f3117ee0d51
     env_file:
       - .env
     environment:

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -56,7 +56,7 @@ services:
 
   redis:
     container_name: immich_redis
-    image: dhi.io/valkey:8@sha256:b82e8e3b9d78b851f9006ba3e7faf1fb4d48db10dda9b5009f01a2551f4aee64
+    image: dhi.io/valkey:9@sha256:735bfb01bd66678e1393fca60710219e787ebeaf9c25a546f1438e7e782d9912
     command: ["valkey-server", "--protected-mode", "no"]
     healthcheck:
       test: redis-cli ping || exit 1

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/csg-development/base-server-dev:202603100822@sha256:bae1e862aec337d31746c725f4037a1085ffbac687dbc3a6e66aebfee9e386be AS builder
+FROM ghcr.io/csg-development/base-server-dev:202606260459@sha256:b1a5625066f59deaf95ae7c5e3bd2ac8a9f2277c7c405adb430c963b737cf3ac AS builder
 # upstream FROM ghcr.io/immich-app/base-server-dev:202603251709@sha256:2bf3053c732fcb87ec90c3c614632ac44847423468ccc57fd935bff771828d9d AS builder
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
   CI=1 \
@@ -72,7 +72,7 @@ RUN --mount=type=cache,id=pnpm-plugins,target=/buildcache/pnpm-store \
   --mount=type=cache,id=mise-tools-${TARGETPLATFORM},target=/buildcache/mise \
   cd plugins && mise run build
 
-FROM ghcr.io/csg-development/base-server-prod:202603100822@sha256:7188061e18249a5a132c66e4de4dfaaceef80d8d806630575daa9e5398b9b341
+FROM ghcr.io/csg-development/base-server-prod:202606260459@sha256:3bb5baa9323014d23accf02eeeaa52a7d1da3a749ebdf5cf37a364b329193d37
 # upstream FROM ghcr.io/immich-app/base-server-prod:202603251709@sha256:17de30977ff87aa06758a56ad7f10d6b5c97bf9dab76e4ec4177a2a8d1b2b5f3
 
 WORKDIR /usr/src/app


### PR DESCRIPTION
… postgres, valkey)

- server/Dockerfile: base-server-dev/prod -> 202606260459 (upstream sync #319, Node 24.14.1)
- docker-compose.prod.yml: postgres -> ghcr.io/csg-development, redis -> dhi.io/valkey:8 with protected-mode no

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
