### PR TITLE
[HCNOVEO-1723] Verification code dialogs duplicate and stack infinitely upon returning from background on

### DIFF
--- a/mobile/lib/services/network/network_monitor.dart
+++ b/mobile/lib/services/network/network_monitor.dart
@@ -5,6 +5,7 @@ import 'package:hc_device/hc_device.dart';
 import 'package:immich_mobile/services/network.service.dart';
 import 'package:immich_mobile/services/network/endpoint_resolver.dart';
 import 'package:immich_mobile/services/network/resolve_trigger_service.dart';
+import 'package:immich_mobile/widgets/forms/login/remote_code_dialog.dart';
 import 'package:logging/logging.dart';
 
 const Duration curatorFastReconnectDebounceDelay = Duration(milliseconds: 800);
@@ -207,6 +208,10 @@ class CuratorNetworkMonitor {
     _log.info('[Network] app lifecycle resumed foreground=true pendingNetworkChange=$_pendingNetworkChange');
     _isAppInForeground = true;
     _reconnectEpisodeService.onAppLifecycleResumed();
+    if (isRemoteCodeModalShowing) {
+      _log.info('[Network] app resume skipped reconnect reason=remote_code_modal_active');
+      return;
+    }
     if (!_canAttemptReconnect()) {
       return;
     }
@@ -532,6 +537,10 @@ class CuratorNetworkMonitor {
   }) async {
     if (remoteProvider.isAuthenticated) {
       _log.fine('[Network] OTP prompt skipped reason=already_authenticated');
+      return;
+    }
+    if (isRemoteCodeModalShowing) {
+      _log.info('[Network] OTP prompt skipped reason=remote_code_modal_active reason=${resolved.reason}');
       return;
     }
     _log.info('[Network] prompting remote access authentication reason=${resolved.reason}');

--- a/mobile/lib/services/network/prompt_remote_access_auth.dart
+++ b/mobile/lib/services/network/prompt_remote_access_auth.dart
@@ -27,6 +27,7 @@ Future<bool> promptRemoteAccessAuth({
     onEmailNotAllowed: onEmailNotAllowed,
     onSuccess: () async => remoteOk = true,
   );
+  remoteOk = remoteOk || remoteProvider.isAuthenticated;
   _log.info('[OTP] promptRemoteAccessAuth end email=$email success=$remoteOk');
   return remoteOk;
 }

--- a/mobile/lib/widgets/forms/login/remote_code_dialog.dart
+++ b/mobile/lib/widgets/forms/login/remote_code_dialog.dart
@@ -13,6 +13,11 @@ final _otpLog = Logger('RemoteCodeDialog');
 
 const int defaultResendCooldownSeconds = 60;
 
+Future<void>? _activeRemoteCodeModalFuture;
+
+/// True while a remote code modal is being presented (including initial code send).
+bool get isRemoteCodeModalShowing => _activeRemoteCodeModalFuture != null;
+
 class RemoteCodeModal extends HookWidget {
   final Future<void> Function()? onSuccess;
   final String email;
@@ -364,6 +369,40 @@ Future<void> showRemoteCodeModal({
   /// When true, skips the automatic [sendCode] before the dialog (e.g. Remote Access
   /// session already present and an extra initiate request is unnecessary).
   bool skipInitialCodeSend = false,
+}) async {
+  final activeSession = _activeRemoteCodeModalFuture;
+  if (activeSession != null) {
+    _otpLog.info('[OTP] showRemoteCodeModal join existing session email=$email');
+    return activeSession;
+  }
+
+  final session = _presentRemoteCodeModal(
+    context: context,
+    remoteProvider: remoteProvider,
+    email: email,
+    onSuccess: onSuccess,
+    onEmailNotAllowed: onEmailNotAllowed,
+    onDialogPresented: onDialogPresented,
+    skipInitialCodeSend: skipInitialCodeSend,
+  );
+  _activeRemoteCodeModalFuture = session;
+  try {
+    await session;
+  } finally {
+    if (identical(_activeRemoteCodeModalFuture, session)) {
+      _activeRemoteCodeModalFuture = null;
+    }
+  }
+}
+
+Future<void> _presentRemoteCodeModal({
+  required BuildContext context,
+  required RemoteProvider remoteProvider,
+  required String email,
+  Future<void> Function()? onSuccess,
+  VoidCallback? onEmailNotAllowed,
+  VoidCallback? onDialogPresented,
+  required bool skipInitialCodeSend,
 }) async {
   _otpLog.info(
     '[OTP] showRemoteCodeModal start email=$email skipInitialCodeSend=$skipInitialCodeSend',


### PR DESCRIPTION
…turning from background on

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
