### PR TITLE
[HCNOVEO-1597] The field 'Connecting to' should be filled with the last device the user was connected to

### DIFF
--- a/mobile/hc_device/lib/providers/device.provider.dart
+++ b/mobile/hc_device/lib/providers/device.provider.dart
@@ -121,6 +121,9 @@ class DeviceState {
   final String? refreshToken;
   final String? login;
   final String? deviceID;
+  // Last device the user connected to. Persisted across logout so the login
+  // form can pre-select it again.
+  final String? lastDeviceID;
   final String? seagateDeviceID;
   final Status? deviceStatus;
   final List<DevicePath>? devicePaths;
@@ -135,6 +138,7 @@ class DeviceState {
     this.refreshToken,
     this.login,
     this.deviceID,
+    this.lastDeviceID,
     this.seagateDeviceID,
     this.deviceStatus,
     this.devicePaths,
@@ -153,6 +157,7 @@ class DeviceState {
     String? refreshToken,
     String? login,
     String? deviceID,
+    String? lastDeviceID,
     String? seagateDeviceID,
     Status? deviceStatus,
     List<DevicePath>? devicePaths,
@@ -177,6 +182,7 @@ class DeviceState {
       refreshToken: clearRefreshToken ? null : (refreshToken ?? this.refreshToken),
       login: login ?? this.login,
       deviceID: clearDeviceId ? null : (deviceID ?? this.deviceID),
+      lastDeviceID: lastDeviceID ?? this.lastDeviceID,
       seagateDeviceID:
           clearSeagateDeviceId ? null : (seagateDeviceID ?? this.seagateDeviceID),
       deviceStatus: clearDeviceStatus ? null : (deviceStatus ?? this.deviceStatus),
@@ -194,6 +200,9 @@ class DeviceProvider extends Notifier<DeviceState>
   static const String basePath = '/api/v1';
   static const String loginKey = "curator_login";
   static const String favoriteDeviceKey = "curator_favorite";
+  // Last connected device id. Unlike [favoriteDeviceKey] it survives logout so
+  // the login form can pre-select the device the user last used.
+  static const String lastDeviceKey = "curator_last_device";
   static const String seagateDeviceIDKey = "curator_seagate_device_id";
   static const String favoriteDevicePathsKey = "curator_favorite_paths";
   static const String cachedDevicePathsKey = "curator_cached_device_paths";
@@ -253,6 +262,7 @@ class DeviceProvider extends Notifier<DeviceState>
     return DeviceState(
       login: _storageData[loginKey] as String?,
       deviceID: _storageData[favoriteDeviceKey] as String?,
+      lastDeviceID: _storageData[lastDeviceKey] as String? ?? _storageData[favoriteDeviceKey] as String?,
       seagateDeviceID: _storageData[seagateDeviceIDKey] as String?,
       refreshToken: deps.secureData[refreshTokenKey],
       devicePaths: initialDevicePaths,
@@ -269,6 +279,7 @@ class DeviceProvider extends Notifier<DeviceState>
   @override
   String? get accessToken => state.accessToken;
   String? get deviceID => state.deviceID;
+  String? get lastDeviceID => state.lastDeviceID;
   String? get seagateDeviceID => state.seagateDeviceID;
   Status? get deviceStatus => state.deviceStatus;
   List<DevicePath>? get devicePaths => state.devicePaths;
@@ -403,6 +414,7 @@ class DeviceProvider extends Notifier<DeviceState>
       login: login ?? state.login,
       deviceStatus: status ?? state.deviceStatus,
       deviceID: deviceID ?? state.deviceID,
+      lastDeviceID: deviceID ?? state.lastDeviceID,
       seagateDeviceID: seagateDeviceID ?? state.seagateDeviceID,
     );
     if (productName != null) {
@@ -439,6 +451,7 @@ class DeviceProvider extends Notifier<DeviceState>
     // Save favorite device in shared preferences
     if (deviceID != null) {
       await asyncPrefs.setString(favoriteDeviceKey, deviceID);
+      await asyncPrefs.setString(lastDeviceKey, deviceID);
       if (seagateDeviceID != null && seagateDeviceID.isNotEmpty) {
         await asyncPrefs.setString(seagateDeviceIDKey, seagateDeviceID);
       } else {

--- a/mobile/lib/widgets/forms/login/curator_login_form.dart
+++ b/mobile/lib/widgets/forms/login/curator_login_form.dart
@@ -213,11 +213,17 @@ class CuratorLoginForm extends HookConsumerWidget {
     preselectFavoriteDevice() {
       if (devices.value.isEmpty) return;
 
-      final favoriteDeviceId = ref.read(deviceProvider).deviceID;
+      final deviceState = ref.read(deviceProvider);
+      // Prefer the currently favorite device, then the last device the user
+      // connected to (survives logout), and fall back to the first in the list.
+      final preferredDeviceId = deviceState.deviceID?.isNotEmpty == true ? deviceState.deviceID : deviceState.lastDeviceID;
 
       DeviceItem? candidateDevice;
-      if (favoriteDeviceId?.isNotEmpty == true) {
-        candidateDevice = devices.value.firstWhereOrNull((d) => d.about?.certificateCommonName == favoriteDeviceId);
+      if (preferredDeviceId?.isNotEmpty == true) {
+        // Match by [DeviceItem.id] — the same value persisted on connect via
+        // setHost(deviceID: device.id). It resolves through remoteDevice first,
+        // so matching only on about?.certificateCommonName misses remote devices.
+        candidateDevice = devices.value.firstWhereOrNull((d) => d.id == preferredDeviceId);
       }
 
       selectedDevice.value = candidateDevice ?? devices.value.firstOrNull;


### PR DESCRIPTION
…the user was connected to

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
