### PR TITLE
[HCNOVEO-1687] Broken navigation stack when returning from an album via "Appears in" section

### DIFF
--- a/mobile/lib/presentation/widgets/asset_viewer/asset_details/appears_in_details.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_details/appears_in_details.widget.dart
@@ -8,8 +8,8 @@ import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/theme_extensions.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/album/album_tile.dart';
-import 'package:immich_mobile/providers/asset_viewer/asset_viewer.provider.dart';
 import 'package:immich_mobile/presentation/widgets/asset_viewer/sheet_tile.widget.dart';
+import 'package:immich_mobile/providers/asset_viewer/video_player_provider.dart';
 import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
@@ -57,9 +57,12 @@ class AppearsInDetails extends ConsumerWidget {
                     return AlbumTile(
                       album: album,
                       isOwner: isOwner,
-                      onAlbumSelected: (album) async {
-                        ref.invalidate(assetViewerProvider);
-                        unawaited(context.router.popAndPush(RemoteAlbumRoute(album: album)));
+                      onAlbumSelected: (album) {
+                        // Keep the asset viewer under the album so Back returns to the photo.
+                        if (asset.isVideo) {
+                          unawaited(ref.read(videoPlayerProvider(asset.heroTag).notifier).pause());
+                        }
+                        unawaited(context.pushRoute(RemoteAlbumRoute(album: album)));
                       },
                     );
                   }).toList(),


### PR DESCRIPTION
…s in" section

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
