### PR TITLE
[HCNOVEO-1813] Infinite loading spinner in select albums modal when there are no media assets

### DIFF
--- a/mobile/lib/pages/backup/drift_backup_album_selection.page.dart
+++ b/mobile/lib/pages/backup/drift_backup_album_selection.page.dart
@@ -19,6 +19,11 @@ import 'package:immich_mobile/widgets/backup/drift_album_info_list_tile.dart';
 import 'package:immich_mobile/widgets/common/search_field.dart';
 import 'package:logging/logging.dart';
 
+final backupAlbumCountProvider = FutureProvider.autoDispose<int>((ref) async {
+  await ref.read(backupAlbumProvider.notifier).getAll();
+  return ref.read(backupAlbumProvider).length;
+});
+
 @RoutePage()
 class DriftBackupAlbumSelectionPage extends ConsumerStatefulWidget {
   const DriftBackupAlbumSelectionPage({super.key});
@@ -44,7 +49,6 @@ class _DriftBackupAlbumSelectionPageState extends ConsumerState<DriftBackupAlbum
     _searchFocusNode = FocusNode();
 
     _enableSyncUploadAlbum.value = ref.read(appSettingsServiceProvider).getSetting(AppSettingsEnum.syncAlbums);
-    ref.read(backupAlbumProvider.notifier).getAll();
 
     _initialTotalAssetCount = ref.read(driftBackupProvider.select((p) => p.totalCount));
   }
@@ -79,6 +83,7 @@ class _DriftBackupAlbumSelectionPageState extends ConsumerState<DriftBackupAlbum
 
   @override
   Widget build(BuildContext context) {
+    final isLoading = ref.watch(backupAlbumCountProvider).isLoading;
     final albums = ref.watch(backupAlbumProvider);
     final albumCount = albums.length;
     // Filter albums based on search query
@@ -244,15 +249,32 @@ class _DriftBackupAlbumSelectionPageState extends ConsumerState<DriftBackupAlbum
                     ],
                   ),
                 ),
-                SliverLayoutBuilder(
-                  builder: (context, constraints) {
-                    if (constraints.crossAxisExtent > 600) {
-                      return _AlbumSelectionGrid(filteredAlbums: filteredAlbums, searchQuery: _searchQuery);
-                    } else {
-                      return _AlbumSelectionList(filteredAlbums: filteredAlbums, searchQuery: _searchQuery);
-                    }
-                  },
-                ),
+                if (filteredAlbums.isEmpty)
+                  SliverToBoxAdapter(
+                    child: Center(
+                      child: _searchQuery.isNotEmpty
+                          ? Padding(
+                              padding: const EdgeInsets.all(24.0),
+                              child: Text('album_search_not_found'.t(context: context)),
+                            )
+                          : isLoading
+                          ? const CircularProgressIndicator()
+                          : Padding(
+                              padding: const EdgeInsets.all(24.0),
+                              child: Text('no_albums_found'.t(context: context)),
+                            ),
+                    ),
+                  )
+                else
+                  SliverLayoutBuilder(
+                    builder: (context, constraints) {
+                      if (constraints.crossAxisExtent > 600) {
+                        return _AlbumSelectionGrid(filteredAlbums: filteredAlbums);
+                      } else {
+                        return _AlbumSelectionList(filteredAlbums: filteredAlbums);
+                      }
+                    },
+                  ),
               ],
             ),
             if (_handleLinkedAlbumFuture != null)
@@ -289,27 +311,11 @@ class _DriftBackupAlbumSelectionPageState extends ConsumerState<DriftBackupAlbum
 
 class _AlbumSelectionList extends StatelessWidget {
   final List<LocalAlbum> filteredAlbums;
-  final String searchQuery;
 
-  const _AlbumSelectionList({required this.filteredAlbums, required this.searchQuery});
+  const _AlbumSelectionList({required this.filteredAlbums});
 
   @override
   Widget build(BuildContext context) {
-    if (filteredAlbums.isEmpty && searchQuery.isNotEmpty) {
-      return SliverToBoxAdapter(
-        child: Center(
-          child: Padding(
-            padding: const EdgeInsets.all(24.0),
-            child: Text('album_search_not_found'.t(context: context)),
-          ),
-        ),
-      );
-    }
-
-    if (filteredAlbums.isEmpty) {
-      return const SliverToBoxAdapter(child: Center(child: CircularProgressIndicator()));
-    }
-
     return SliverPadding(
       padding: const EdgeInsets.symmetric(vertical: 12.0),
       sliver: SliverList(
@@ -323,27 +329,11 @@ class _AlbumSelectionList extends StatelessWidget {
 
 class _AlbumSelectionGrid extends StatelessWidget {
   final List<LocalAlbum> filteredAlbums;
-  final String searchQuery;
 
-  const _AlbumSelectionGrid({required this.filteredAlbums, required this.searchQuery});
+  const _AlbumSelectionGrid({required this.filteredAlbums});
 
   @override
   Widget build(BuildContext context) {
-    if (filteredAlbums.isEmpty && searchQuery.isNotEmpty) {
-      return SliverToBoxAdapter(
-        child: Center(
-          child: Padding(
-            padding: const EdgeInsets.all(24.0),
-            child: Text('album_search_not_found'.t(context: context)),
-          ),
-        ),
-      );
-    }
-
-    if (filteredAlbums.isEmpty) {
-      return const SliverToBoxAdapter(child: Center(child: CircularProgressIndicator()));
-    }
-
     return SliverPadding(
       padding: const EdgeInsets.all(12.0),
       sliver: SliverGrid.builder(


### PR DESCRIPTION
…o media assets

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have carefully read CONTRIBUTING.md
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
