### PR TITLE
[HCNOVEO-1811] "Finding network" toast is skipped and "Connection lost" banner is displayed after the device turned off

### DIFF
--- a/mobile/lib/services/network/network_monitor_callbacks.dart
+++ b/mobile/lib/services/network/network_monitor_callbacks.dart
@@ -124,6 +124,18 @@ class CuratorAppNetworkMonitorCallbacks implements CuratorNetworkMonitorCallback
     if (!hasUsableTransport) {
       return NetworkBannerKind.noInternet;
     }
+    // Like the debug overlay, derive from the live resolver state. Transport is
+    // usable here (checked above), so while a resolve is actively searching:
+    //  - keep an already-shown "finding" through transient status blips, and
+    //  - promote a now-stale "no internet" (left over from when transport was
+    //    off) to "finding" — we're back online and probing.
+    // 'unable' (Connection lost) is deliberately left alone so steady failures
+    // don't flip to finding on background retries.
+    final activeKind = _bannerController.activeKind;
+    if ((activeKind == NetworkBannerKind.finding || activeKind == NetworkBannerKind.noInternet) &&
+        _ref.read(pathResolveTriggerServiceProvider).isResolving) {
+      return NetworkBannerKind.finding;
+    }
     final status = _ref.read(connectionStateProvider).status;
     if (status == conn.ConnectionStatus.reconnecting) {
       // 'reconnecting' is published by any failed request (see


### PR DESCRIPTION
…is displayed after the device turned off

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have carefully read CONTRIBUTING.md
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
