### PR TITLE
[HCNOVEO-1823] iOS: Spurious network change detection triggers unexpected OTP request during initial sync

### DIFF
--- a/mobile/hc_device/lib/services/device_detection_service.dart
+++ b/mobile/hc_device/lib/services/device_detection_service.dart
@@ -31,9 +31,18 @@ import 'package:nsd/nsd.dart' as nsd;
 const String serviceTypeDiscover = '_https._tcp';
 const String serviceTxtKeyDiscover = 'seagate';
 const String serviceTxtValueDiscover = 'homecloud';
-const Duration defaultDurationLocalDetection = Duration(seconds: 5);
+// Long enough for a cold mDNS cache to answer a retransmit; a short 5s window
+// often misses a present device and forces a premature OTP fallback.
+const Duration defaultDurationLocalDetection = Duration(seconds: 8);
 const Duration timeoutLocalApiCall = Duration(seconds: 4);
 const Duration timeoutRemoteApiCall = Duration(seconds: 9);
+// A logout (or airplane-mode toggle) can make connectivity_plus briefly report
+// no wifi even though the device is still on it. Skipping local mDNS on that
+// transient report completes detection instantly with no devices and forces a
+// premature OTP prompt. Re-check across this settle window before concluding
+// wifi is really gone, so mDNS still runs its full window when wifi is present.
+const Duration wifiSettleBeforeLocalDetectionSkip = Duration(seconds: 2);
+const Duration wifiSettleRecheckInterval = Duration(milliseconds: 400);
 
 String _devicePathMultisetKey(DevicePath p) {
   final addr = p.address.trim().toLowerCase();
@@ -92,6 +101,7 @@ class DeviceDetectionService {
   bool _isDetecting = false;
   bool _isCancelled = false;
   bool _remoteDetectionDone = false;
+  bool _detectionCompleted = false;
   int _operationId = 0;
   int _detectionCounter = 0;
   final Map<String, DeviceItem> _devices = {};
@@ -121,6 +131,7 @@ class DeviceDetectionService {
     _isDetecting = true;
     _isCancelled = false;
     _remoteDetectionDone = false;
+    _detectionCompleted = false;
     _devices.clear();
 
     logger.info('[Network] Starting detection');
@@ -167,6 +178,29 @@ class DeviceDetectionService {
     }
   }
 
+  /// Wait briefly for a transient no-wifi report to settle before concluding
+  /// local mDNS must be skipped. Returns true as soon as wifi reappears within
+  /// [wifiSettleBeforeLocalDetectionSkip], false if it stays absent (genuinely
+  /// off wifi) or the detection is cancelled/superseded meanwhile.
+  Future<bool> _awaitWifiSettle(int operationId) async {
+    logger.info(
+      '[Network] No WiFi at detection start, waiting up to '
+      '${wifiSettleBeforeLocalDetectionSkip.inMilliseconds}ms for it to settle',
+    );
+    final deadline = DateTime.now().add(wifiSettleBeforeLocalDetectionSkip);
+    while (DateTime.now().isBefore(deadline)) {
+      await Future<void>.delayed(wifiSettleRecheckInterval);
+      if (_isCancelled || operationId != _operationId) {
+        return false;
+      }
+      if (await _checkWiFiConnectivity()) {
+        logger.info('[Network] WiFi settled, proceeding with local detection');
+        return true;
+      }
+    }
+    return false;
+  }
+
   /// Start mDNS detection of local devices
   Future<void> _startLocalDetection(int operationId) async {
     if (_discovery != null || _isCancelled) {
@@ -177,8 +211,15 @@ class DeviceDetectionService {
     }
     _updateDetectionCounter(1);
 
-    final hasWiFi = await _checkWiFiConnectivity();
+    var hasWiFi = await _checkWiFiConnectivity();
     if (operationId != _operationId) return;
+    if (!hasWiFi) {
+      // Tolerate a transient no-wifi report (e.g. right after logout) before
+      // giving up on local mDNS — otherwise detection completes empty and
+      // prompts OTP without ever having searched the local network.
+      hasWiFi = await _awaitWifiSettle(operationId);
+      if (operationId != _operationId) return;
+    }
     if (!hasWiFi) {
       logger.warning(
         '[Network] Skipping local detection due to no WiFi connectivity',
@@ -220,7 +261,10 @@ class DeviceDetectionService {
           logger.info(
             '[Network] Device discovered on local network by mDNS: ${service.name}',
           );
-          // Get About info to obtain certificateCommonName and confirm it's a valid HomeCloud device before adding to the list
+          // Confirm it's a valid HomeCloud device before adding. Count the
+          // lookup so detection doesn't complete (→ OTP) while it's in flight.
+          if (operationId != _operationId) return;
+          _updateDetectionCounter(1);
           getAbout(
             DeviceProvider.createBaseUrl(host, port),
           ).then((about) {
@@ -250,6 +294,10 @@ class DeviceDetectionService {
                 '[Network] Added device: ${device.name} at ${device.baseUrl}',
               );
               onDeviceFound?.call(device);
+            }
+          }).whenComplete(() {
+            if (operationId == _operationId) {
+              _updateDetectionCounter(-1);
             }
           });
         }
@@ -301,6 +349,11 @@ class DeviceDetectionService {
         _startRemoteDetection(_operationId);
         return;
       }
+      // A late About lookup must not re-fire completion.
+      if (_detectionCompleted) {
+        return;
+      }
+      _detectionCompleted = true;
       logger.info(
         '[Network] Detection finished, found ${_devices.length} devices',
       );

--- a/mobile/hc_device/lib/services/path_resolver/hc_path_resolver.dart
+++ b/mobile/hc_device/lib/services/path_resolver/hc_path_resolver.dart
@@ -581,10 +581,10 @@ class HcPathResolver {
 
   String? get availablePathType => _availablePathType;
 
+  /// The type describes the current [_availablePath], so an unknown candidate
+  /// clears it rather than leaving a stale (possibly local) label behind.
   void _persistPathType(String? candidate) {
-    if (HcPathType.isKnown(candidate)) {
-      _availablePathType = candidate;
-    }
+    _availablePathType = HcPathType.isKnown(candidate) ? candidate : null;
   }
 
   Future<bool> _hasWiFiConnectivity() async {

--- a/mobile/lib/providers/network/network_monitor.provider.dart
+++ b/mobile/lib/providers/network/network_monitor.provider.dart
@@ -63,6 +63,7 @@ final curatorNetworkMonitorProvider = Provider<CuratorNetworkMonitor>((ref) {
   final callbacks = CuratorAppNetworkMonitorCallbacks(
     ref,
     onFindingNetworkToastDismissed: () => monitor.noteUserDismissedFindingToast(),
+    onManualRetry: () => monitor.forceManualRetry(),
   );
   monitor = CuratorNetworkMonitor(
     deviceProvider: ref.read(deviceProvider.notifier),

--- a/mobile/lib/services/network/endpoint_resolver.dart
+++ b/mobile/lib/services/network/endpoint_resolver.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:hc_device/api/remote_access.enums.swagger.dart' show DevicePathType;
 import 'package:hc_device/hc_device.dart';
 import 'package:immich_mobile/services/api.service.dart';
 import 'package:immich_mobile/utils/async_mutex.dart';
@@ -117,6 +118,15 @@ class HcDeviceEndpointResolver {
 
   String? getAvailablePath() => _resolver.getAvailablePath();
   String? getAvailablePathType() => _resolver.availablePathType;
+
+  /// Records the type of a path selected outside a resolve (login probes paths
+  /// itself), so recovery can trust it: a local cached path may cheap-probe
+  /// past a resolve, a remote one must not.
+  Future<void> noteSelectedPath(String endpoint, {DevicePathType? pathType}) async {
+    final resolvedPathType = HcPathType.fromDevicePathType(pathType);
+    _log.info('[Resolver] external path selection endpoint=$endpoint pathType=${resolvedPathType ?? '-'}');
+    await _resolver.setAvailablePath(endpoint, pathType: resolvedPathType);
+  }
 
   List getDevicePaths(String remoteDeviceId) => _resolver.getDevicePaths(remoteDeviceId);
 

--- a/mobile/lib/services/network/network_monitor.dart
+++ b/mobile/lib/services/network/network_monitor.dart
@@ -164,6 +164,9 @@ class CuratorNetworkMonitor implements RecoveryExecutorCallbacks {
     _resetLocalNetPermissionState();
     _reconnectEpisodeService.reset();
     _executor.lastFailureSignature = null;
+    _snapshotBuilder.hasEstablishedConnectedThisLaunch = false;
+    _snapshotBuilder.networkIdentity = null;
+    _snapshotBuilder.lastConnectedNetworkIdentity = null;
     _log.info('[Network] Stopped monitoring network changes');
   }
 
@@ -187,6 +190,13 @@ class CuratorNetworkMonitor implements RecoveryExecutorCallbacks {
       // New transport episode — reset any pending local-network-permission
       // re-resolve so its bound starts fresh for the new network.
       _resetLocalNetPermissionState();
+      // A different network may fail for a different reason - re-arm the
+      // duplicate-failure suppression so OTP/unable can surface again. Done
+      // before the backgrounded return: switching wifi from the system shade
+      // always lands here with the app in the background, and the deferred
+      // recovery that runs on resume must not inherit the old network's
+      // failure signature.
+      _executor.lastFailureSignature = null;
     }
 
     if (!_isAppInForeground) {
@@ -201,9 +211,6 @@ class CuratorNetworkMonitor implements RecoveryExecutorCallbacks {
     if (!hadPrevious) {
       _log.fine('[Network] Initial connectivity status: $results');
     } else if (changed) {
-      // A different network may fail for a different reason - re-arm the
-      // duplicate-failure suppression so OTP/unable can surface again.
-      _executor.lastFailureSignature = null;
       _scheduleRecovery(
         RecoveryEvent(trigger: RecoveryTrigger.connectivityChange, detail: 'transport changed: $results'),
       );
@@ -280,6 +287,14 @@ class CuratorNetworkMonitor implements RecoveryExecutorCallbacks {
       }
     }
     if (_deferredWhileBackgrounded) {
+      // The network changed out of sight (wifi switched from the system shade),
+      // and identity refresh does not run while backgrounded. Re-observe it
+      // before the deferred recovery so that run judges the network it is
+      // actually on. triggerReconnectOnChange: false — the deferred recovery
+      // below already covers the change.
+      await _refreshNetworkIdentity(source: 'resume_deferred', triggerReconnectOnChange: false);
+    }
+    if (_deferredWhileBackgrounded) {
       _deferredWhileBackgrounded = false;
       await _runRecovery(
         const RecoveryEvent(
@@ -309,6 +324,11 @@ class CuratorNetworkMonitor implements RecoveryExecutorCallbacks {
 
   void onConnectionRestored() {
     _isReconnecting = false;
+    _snapshotBuilder.hasEstablishedConnectedThisLaunch = true;
+    // Remember which network served this connection: a later connectivity-driven
+    // failure on that same network is an outage to report, not a network switch
+    // that warrants an OTP prompt.
+    _snapshotBuilder.lastConnectedNetworkIdentity = _lastNetworkIdentitySignature;
     _reconnectEpisodeService.onConnectionRestored();
   }
 
@@ -466,6 +486,9 @@ class CuratorNetworkMonitor implements RecoveryExecutorCallbacks {
 
       final previous = _lastNetworkIdentitySignature;
       _lastNetworkIdentitySignature = identity;
+      // Feeds the failure signature and the same-network-outage check, so it
+      // must be current before any recovery that follows this refresh.
+      _snapshotBuilder.networkIdentity = identity;
 
       if (previous != null && previous != identity) {
         // ssid/ip can change without a transport change (wifi handoff), so the

--- a/mobile/lib/services/network/network_monitor_callbacks.dart
+++ b/mobile/lib/services/network/network_monitor_callbacks.dart
@@ -26,11 +26,16 @@ import 'package:immich_mobile/widgets/common/network_status_snackbar.widget.dart
 import 'package:logging/logging.dart';
 
 class CuratorAppNetworkMonitorCallbacks implements CuratorNetworkMonitorCallbacks {
-  CuratorAppNetworkMonitorCallbacks(this._ref, {required VoidCallback onFindingNetworkToastDismissed})
-    : _onFindingNetworkToastDismissed = onFindingNetworkToastDismissed;
+  CuratorAppNetworkMonitorCallbacks(
+    this._ref, {
+    required VoidCallback onFindingNetworkToastDismissed,
+    required VoidCallback onManualRetry,
+  }) : _onFindingNetworkToastDismissed = onFindingNetworkToastDismissed,
+       _onManualRetry = onManualRetry;
 
   final Ref _ref;
   final VoidCallback _onFindingNetworkToastDismissed;
+  final VoidCallback _onManualRetry;
   final _log = Logger('CuratorAppNetworkMonitorCallbacks');
   bool _lastReconnectionFailureWasNetwork = false;
   bool _lastFailureHadInternet = true;
@@ -42,7 +47,8 @@ class CuratorAppNetworkMonitorCallbacks implements CuratorNetworkMonitorCallback
   late final NetworkBannerController _bannerController = NetworkBannerController(
     contextGetter: () => _navigatorContext,
     onFindingDismissed: _onFindingNetworkToastDismissed,
-    onRetry: () => _ref.read(curatorNetworkMonitorProvider).forceManualRetry(),
+    // Injected: reading curatorNetworkMonitorProvider via this Ref would self-depend.
+    onRetry: _onManualRetry,
   );
 
   @override
@@ -151,9 +157,9 @@ class CuratorAppNetworkMonitorCallbacks implements CuratorNetworkMonitorCallback
       if (!_lastFailureHadInternet) {
         return NetworkBannerKind.noInternet;
       }
-      // 'Connection lost' is only meaningful with a remote access session;
-      // without one the OTP flow is the recovery UX.
-      return _ref.read(remoteProvider).isAuthenticated ? NetworkBannerKind.unable : NetworkBannerKind.hidden;
+      // Shown for local-only sessions too: its Retry re-runs as a manual retry
+      // (which prompts OTP), so it's the feedback + manual escape hatch.
+      return NetworkBannerKind.unable;
     }
     return NetworkBannerKind.hidden;
   }

--- a/mobile/lib/services/network/recovery/recovery_executor.dart
+++ b/mobile/lib/services/network/recovery/recovery_executor.dart
@@ -23,6 +23,9 @@ class SnapshotBuilder {
     this.isResolving = false,
     this.isAppInForeground = true,
     this.cachedPathType,
+    this.hasEstablishedConnectedThisLaunch = false,
+    this.networkIdentity,
+    this.lastConnectedNetworkIdentity,
   });
 
   final DeviceProvider deviceProvider;
@@ -32,6 +35,15 @@ class SnapshotBuilder {
   bool isResolving;
   bool isAppInForeground;
   String? cachedPathType;
+
+  /// Latched by [CuratorNetworkMonitor] when any connect succeeds this session.
+  bool hasEstablishedConnectedThisLaunch;
+
+  /// Identity of the current network, kept fresh by [CuratorNetworkMonitor].
+  String? networkIdentity;
+
+  /// [networkIdentity] at the last successful connect this session.
+  String? lastConnectedNetworkIdentity;
 
   Future<NetworkSnapshot> build(RecoveryEvent event) async {
     final connectivity = await (readConnectivity ?? Connectivity().checkConnectivity)();
@@ -60,6 +72,9 @@ class SnapshotBuilder {
       transport: transport,
       isResolving: isResolving,
       otpModalShowing: isOtpModalShowing(),
+      hasEstablishedConnectedThisLaunch: hasEstablishedConnectedThisLaunch,
+      networkIdentity: networkIdentity,
+      lastConnectedNetworkIdentity: lastConnectedNetworkIdentity,
     );
   }
 }
@@ -152,7 +167,7 @@ class RecoveryExecutor {
           suppressFindingToast: snapshot.event.suppressFindingToast,
         );
         final resolved = await _resolve(snapshot, probeMode: probeMode);
-        await _handleResolveResult(snapshot, resolved);
+        await _handleResolveResult(snapshot, resolved, cachedProbeAlreadyMissed: cheapProbeFirst);
         return;
     }
   }
@@ -215,6 +230,7 @@ class RecoveryExecutor {
       await Future<void>.delayed(policy.offWifiOtpGraceDelay);
       final settled = await snapshotBuilder.build(snapshot.event);
       lastSnapshot = settled;
+      lastSnapshotAt = DateTime.now();
       if (settled.remoteAuth || settled.otpModalShowing) {
         _log.info('[Recovery] off-wifi OTP aborted after grace: state changed');
         return;
@@ -245,6 +261,32 @@ class RecoveryExecutor {
     });
   }
 
+  /// Returns true when the cached endpoint answered and connected was published.
+  Future<bool> _recoverViaCachedEndpointIfReachable(
+    NetworkSnapshot snapshot, {
+    required String reason,
+    bool alreadyProbedThisRun = false,
+  }) async {
+    final endpoint = snapshot.activeEndpoint;
+    if (!snapshot.hasWifi || endpoint == null || endpoint.isEmpty) {
+      return false;
+    }
+    // A re-probe of an endpoint this run already found dead only has to catch
+    // one that came back during the resolve, so it gets the short timeout —
+    // the full one would just push the OTP modal further out.
+    final timeout = alreadyProbedThisRun ? policy.postFailProbeTimeout : policy.cachedProbeTimeout;
+    final reachable = await callbacks.probeCachedEndpoint(timeout: timeout);
+    lastSnapshot = snapshot.copyWith(cachedEndpointReachable: reachable);
+    lastSnapshotAt = DateTime.now();
+    if (!reachable) {
+      return false;
+    }
+    lastPlanDebugReason = reason;
+    _log.info('[Recovery] cached endpoint reachable ($reason), skipping OTP');
+    callbacks.onPublishConnected();
+    return true;
+  }
+
   Future<EndpointResolutionResult> _resolve(
     NetworkSnapshot snapshot, {
     required PathProbeMode probeMode,
@@ -267,6 +309,7 @@ class RecoveryExecutor {
     NetworkSnapshot snapshot,
     EndpointResolutionResult resolved, {
     bool isRetry = false,
+    bool cachedProbeAlreadyMissed = false,
   }) async {
     _log.info(
       '[Recovery] resolve result success=${resolved.success} reason=${resolved.reason} '
@@ -280,14 +323,22 @@ class RecoveryExecutor {
     }
 
     final reason = ResolveFailureReasonX.fromWire(resolved.reason);
+    // The network identity is part of the signature: the same failure reason on
+    // a different network is a different event and must be able to surface its
+    // own OTP / banner, not read as a repeat of the previous network's failure.
     final signature = [
       snapshot.trigger.name,
       reason.wireValue,
       snapshot.remoteAuth.toString(),
       snapshot.certificateCommonName ?? '-',
       snapshot.seagateDeviceId ?? '-',
+      snapshot.networkIdentity ?? '-',
     ].join('|');
-    final isDuplicate = snapshot.trigger.isConnectivityDriven && lastFailureSignature == signature;
+    // Soft-local retry is still the same recovery run — do not treat its
+    // identical failure as a duplicate connectivity event (that suppression
+    // is for a later queued transport change, not the in-run retry).
+    final isDuplicate =
+        !isRetry && snapshot.trigger.isConnectivityDriven && lastFailureSignature == signature;
     lastFailureSignature = signature;
     if (isDuplicate) {
       lastPlanDebugReason = 'duplicate_connectivity_failure';
@@ -314,13 +365,62 @@ class RecoveryExecutor {
         mode: snapshot.mode,
         trigger: 'api_error_local_retry',
       );
-      await _handleResolveResult(snapshot, retried, isRetry: true);
+      await _handleResolveResult(
+        snapshot,
+        retried,
+        isRetry: true,
+        cachedProbeAlreadyMissed: cachedProbeAlreadyMissed,
+      );
       return;
     }
 
-    if (snapshot.hasLoginEmail && !snapshot.otpModalShowing) {
+    // Mid-session automatic probes must not auto-escalate to OTP (spam during
+    // heavy sync). Cold start / pre-connect failures still may — there has been
+    // no successful connect this launch yet. Banner Retry → manualRetry → OTP.
+    final isBackgroundProbe = snapshot.trigger == RecoveryTrigger.apiTransportError ||
+        snapshot.trigger == RecoveryTrigger.healthProbeMiss;
+    final suppressOtpForBackgroundProbe =
+        isBackgroundProbe && snapshot.hasEstablishedConnectedThisLaunch;
+
+    // A transport flap on the very network that last served a working
+    // connection is a device-side outage (HC or router restarting), not a move
+    // to a network without a local path — remote access is not the answer, the
+    // Retry banner is. Only a positively confirmed identity match suppresses;
+    // an unknown identity still prompts, so a real network switch is never
+    // mistaken for a flap. Manual Retry is not connectivity-driven and stays
+    // able to reach OTP.
+    final isSameNetworkOutage =
+        snapshot.trigger.isConnectivityDriven && snapshot.isSameNetworkAsLastConnect;
+
+    if (snapshot.hasLoginEmail &&
+        !snapshot.otpModalShowing &&
+        !suppressOtpForBackgroundProbe &&
+        !isSameNetworkOutage) {
+      // Airplane / transport flaps: mDNS resolve can fail while the cached LAN
+      // IP is already answering again (sync may even be mid-flight). Last-chance
+      // probe before OTP avoids a false remote-access modal on a live local path.
+      if (await _recoverViaCachedEndpointIfReachable(
+        snapshot,
+        reason: 'post_fail_cached_reachable',
+        alreadyProbedThisRun: cachedProbeAlreadyMissed,
+      )) {
+        return;
+      }
       lastPlanDebugReason = 'post_fail_prompt_otp';
       await _promptOtp(snapshot);
+      return;
+    }
+
+    if (isSameNetworkOutage) {
+      lastPlanDebugReason = 'post_fail_same_network_outage_unable';
+      _log.info('[Recovery] same network as last connect, reporting unable instead of OTP');
+      await callbacks.onReconnectionFailed();
+      return;
+    }
+
+    if (suppressOtpForBackgroundProbe) {
+      lastPlanDebugReason = 'post_fail_background_probe_unable';
+      await callbacks.onReconnectionFailed();
       return;
     }
 

--- a/mobile/lib/services/network/recovery/recovery_models.dart
+++ b/mobile/lib/services/network/recovery/recovery_models.dart
@@ -24,9 +24,15 @@ extension RecoveryTriggerX on RecoveryTrigger {
 
   bool get isConnectivityDriven => this == RecoveryTrigger.connectivityChange;
 
+  /// Re-probe the cached endpoint and short-circuit if it answers, before a
+  /// full resolve. Includes [connectivityChange]: airplane / wifi flaps often
+  /// leave the same LAN IP reachable while mDNS discovery is still empty —
+  /// probing first avoids escalating to OTP. Excludes [healthProbeMiss]: the
+  /// health probe just found the endpoint unreachable, so a second probe is
+  /// redundant — resolve (and the finding toast) start immediately instead.
   bool get prefersCheapProbeFirst =>
       this == RecoveryTrigger.appResume ||
-      this == RecoveryTrigger.healthProbeMiss ||
+      this == RecoveryTrigger.connectivityChange ||
       this == RecoveryTrigger.apiTransportError ||
       this == RecoveryTrigger.manualRetry;
 
@@ -186,6 +192,9 @@ class NetworkSnapshot {
     required this.isResolving,
     required this.otpModalShowing,
     this.cachedEndpointReachable,
+    this.hasEstablishedConnectedThisLaunch = false,
+    this.networkIdentity,
+    this.lastConnectedNetworkIdentity,
   });
 
   final RecoveryEvent event;
@@ -212,7 +221,44 @@ class NetworkSnapshot {
   final bool isResolving;
   final bool otpModalShowing;
 
+  /// True after any successful connect in this monitoring session (recovery
+  /// publish or API success). Used to keep mid-session background probes from
+  /// auto-escalating to OTP while still allowing OTP on cold-start failures.
+  final bool hasEstablishedConnectedThisLaunch;
+
+  /// Opaque identity of the network the device is on (transport + ssid + ip),
+  /// as computed by the monitor. Null when it has not been observed yet.
+  final String? networkIdentity;
+
+  /// [networkIdentity] captured at the last successful connect this launch.
+  final String? lastConnectedNetworkIdentity;
+
   RecoveryTrigger get trigger => event.trigger;
+
+  /// Whether [networkIdentity] carries enough to tell two networks apart. The
+  /// OS can withhold both ssid (iOS: needs location permission) and ip, leaving
+  /// every network looking alike — such an identity must never be used to
+  /// conclude "same network".
+  bool get hasInformativeNetworkIdentity {
+    final identity = networkIdentity;
+    if (identity == null || identity.isEmpty) {
+      return false;
+    }
+    return identity.contains('ssid:') && !identity.contains('ssid:-') ||
+        identity.contains('ip:') && !identity.contains('ip:-');
+  }
+
+  /// True only when we can positively confirm the device is still on the very
+  /// network that last served a working connection. Deliberately false on any
+  /// doubt (identity unknown or uninformative, no connect yet this launch) so
+  /// an unresolvable network still escalates to OTP.
+  bool get isSameNetworkAsLastConnect {
+    final connected = lastConnectedNetworkIdentity;
+    if (connected == null || !hasInformativeNetworkIdentity) {
+      return false;
+    }
+    return connected == networkIdentity;
+  }
 
   bool get hasUsableTransport => transport.hasUsableTransport;
 
@@ -237,6 +283,9 @@ class NetworkSnapshot {
     TransportKind? transport,
     bool? isResolving,
     bool? otpModalShowing,
+    bool? hasEstablishedConnectedThisLaunch,
+    String? networkIdentity,
+    String? lastConnectedNetworkIdentity,
   }) {
     return NetworkSnapshot(
       event: event ?? this.event,
@@ -255,6 +304,10 @@ class NetworkSnapshot {
       transport: transport ?? this.transport,
       isResolving: isResolving ?? this.isResolving,
       otpModalShowing: otpModalShowing ?? this.otpModalShowing,
+      hasEstablishedConnectedThisLaunch:
+          hasEstablishedConnectedThisLaunch ?? this.hasEstablishedConnectedThisLaunch,
+      networkIdentity: networkIdentity ?? this.networkIdentity,
+      lastConnectedNetworkIdentity: lastConnectedNetworkIdentity ?? this.lastConnectedNetworkIdentity,
     );
   }
 
@@ -264,5 +317,8 @@ class NetworkSnapshot {
   String toString() =>
       'NetworkSnapshot(trigger=${trigger.name}, mode=${mode.name}, transport=${transport.name}, '
       'photosAuth=$photosAuthenticated, remoteAuth=$remoteAuth, knownDevice=$knownDevice, '
-      'endpoint=$activeEndpoint, reachable=$cachedEndpointReachable, otpModal=$otpModalShowing)';
+      'endpoint=$activeEndpoint, cachedPathType=${cachedPathType ?? '-'}, '
+      'reachable=$cachedEndpointReachable, otpModal=$otpModalShowing, '
+      'establishedThisLaunch=$hasEstablishedConnectedThisLaunch, '
+      'identity=[${networkIdentity ?? '-'}], lastConnectedIdentity=[${lastConnectedNetworkIdentity ?? '-'}])';
 }

--- a/mobile/lib/services/network/recovery/recovery_policy.dart
+++ b/mobile/lib/services/network/recovery/recovery_policy.dart
@@ -11,19 +11,27 @@ import 'package:immich_mobile/services/network/recovery/recovery_models.dart';
 /// - already resolving → await the active resolve
 /// - transport none → no internet
 /// - off-wifi: RA authenticated → remote-only resolve; email → OTP; else unable
-/// - on-wifi: cheap cached-endpoint probe for resume/health/apiError/manual,
-///   otherwise full resolve (remote-only when backgrounded)
+/// - on-wifi: cheap cached-endpoint probe for resume/connectivity/apiError/manual
+///   (not healthProbeMiss — probe already missed), otherwise full resolve
+///   (remote-only when backgrounded)
 ///
 /// Failure handling after a resolve (local retry → OTP → unable) is a linear
 /// flow in RecoveryExecutor, not a policy re-entry.
 class RecoveryPolicy {
   const RecoveryPolicy({
     this.cachedProbeTimeout = const Duration(seconds: 5),
+    this.postFailProbeTimeout = const Duration(seconds: 2),
     this.offWifiOtpGraceDelay = const Duration(seconds: 3),
     this.transportSettleDelay = const Duration(milliseconds: 1500),
   });
 
   final Duration cachedProbeTimeout;
+
+  /// Timeout for the last-chance endpoint probe before OTP when this run's
+  /// cheap probe already missed. Only has to catch an endpoint that recovered
+  /// during the resolve, so it is deliberately shorter than
+  /// [cachedProbeTimeout] — the modal should not wait a second full timeout.
+  final Duration postFailProbeTimeout;
 
   /// Grace period before prompting OTP when a transport change / resume lands
   /// us off wifi. Networks come up in stages after airplane mode (cellular
@@ -99,16 +107,13 @@ class RecoveryPolicy {
   RecoveryDecision _decideLocalFirst(NetworkSnapshot snapshot) {
     final endpoint = snapshot.activeEndpoint;
     // A reachable cached endpoint short-circuits the resolve, so allow that
-    // only when the cached path is local (or its type is unknown). With a
-    // remote/public path cached on wifi the spec requires searching for a
-    // local path: the full resolve probes local and remote in parallel and
-    // path upgrade switches to local even when it answers later.
-    final cachedPathIsLocalOrUnknown =
-        snapshot.cachedPathType == null || snapshot.cachedPathType == HcPathType.local;
+    // only for a local path. A remote/public one (and an unknown type, since a
+    // remote endpoint answers from any network) must run the full resolve so
+    // wifi can upgrade to local — otherwise the app stays stranded on remote.
     if (snapshot.trigger.prefersCheapProbeFirst &&
         endpoint != null &&
         endpoint.isNotEmpty &&
-        cachedPathIsLocalOrUnknown) {
+        snapshot.cachedPathType == HcPathType.local) {
       return const ResolvePaths(
         'local_first_cheap_probe',
         probeMode: PathProbeMode.all,

--- a/mobile/lib/widgets/forms/login/curator_login_form.dart
+++ b/mobile/lib/widgets/forms/login/curator_login_form.dart
@@ -18,6 +18,7 @@ import 'package:immich_mobile/providers/backup/backup.provider.dart';
 import 'package:immich_mobile/providers/developer_options.provider.dart';
 import 'package:immich_mobile/providers/device_path_refresh.provider.dart';
 import 'package:immich_mobile/providers/gallery_permission.provider.dart';
+import 'package:immich_mobile/providers/network/network_monitor.provider.dart';
 import 'package:immich_mobile/providers/server_info.provider.dart';
 import 'package:immich_mobile/providers/websocket.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
@@ -37,6 +38,7 @@ import 'package:logging/logging.dart';
 import 'package:openapi/api.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
+import 'package:hc_device/api/remote_access.enums.swagger.dart' show DevicePathType;
 import 'package:hc_device/hc_device.dart';
 
 class CuratorLoginForm extends HookConsumerWidget {
@@ -516,6 +518,7 @@ class CuratorLoginForm extends HookConsumerWidget {
     Future<bool> syncServerEndpointWithBaseUrl({
       required Uri baseUrl,
       required String flowTag,
+      DevicePathType? pathType,
     }) async {
       final normalizedBaseUrl = buildDevicePhotosBaseUrl(baseUrl);
       final sanitizedServerUrl = sanitizeUrl(normalizedBaseUrl);
@@ -528,8 +531,14 @@ class CuratorLoginForm extends HookConsumerWidget {
       }
 
       try {
-        await ref.read(authProvider.notifier).validateServerUrl(normalizedServerUrl);
-        log.info('[$flowTag] Endpoint synced to selected device: $normalizedServerUrl');
+        final resolvedServerUrl = await ref.read(authProvider.notifier).validateServerUrl(normalizedServerUrl);
+        // Login picks the path itself; record its type so recovery does not
+        // have to re-resolve to learn it (see noteSelectedPath).
+        await ref.read(hcDeviceEndpointResolverProvider).noteSelectedPath(resolvedServerUrl, pathType: pathType);
+        log.info(
+          '[$flowTag] Endpoint synced to selected device: $normalizedServerUrl '
+          'pathType=${pathType?.value ?? '-'}',
+        );
         return true;
       } on ApiException catch (e) {
         warningMessage.value = e.message ?? 'login_form_api_exception'.tr();
@@ -569,7 +578,11 @@ class CuratorLoginForm extends HookConsumerWidget {
         if (ping == null || ping.baseUrl == null) {
           return false;
         }
-        final endpointSynced = await syncServerEndpointWithBaseUrl(baseUrl: ping.baseUrl!, flowTag: 'Login');
+        final endpointSynced = await syncServerEndpointWithBaseUrl(
+          baseUrl: ping.baseUrl!,
+          flowTag: 'Login',
+          pathType: ping.pathType,
+        );
         if (!endpointSynced) {
           return false;
         }
@@ -598,12 +611,14 @@ class CuratorLoginForm extends HookConsumerWidget {
       }
 
       var baseUrl = device.baseUrl;
+      var selectedPathType = device.pathType;
       if (baseUrl == null && device.remoteDevice != null) {
         final ping = await resolveRemoteDeviceConnection(device: device, flowTag: 'Login', requireFreshPaths: true);
         if (ping == null) {
           return false;
         }
         baseUrl = ping.baseUrl;
+        selectedPathType = ping.pathType;
       }
 
       if (baseUrl == null) {
@@ -613,7 +628,11 @@ class CuratorLoginForm extends HookConsumerWidget {
       }
 
       clearAllErrors();
-      final endpointSynced = await syncServerEndpointWithBaseUrl(baseUrl: baseUrl, flowTag: 'Login');
+      final endpointSynced = await syncServerEndpointWithBaseUrl(
+        baseUrl: baseUrl,
+        flowTag: 'Login',
+        pathType: selectedPathType,
+      );
       if (!endpointSynced) {
         return false;
       }
@@ -762,7 +781,9 @@ class CuratorLoginForm extends HookConsumerWidget {
       }
     }
 
-    Future<bool> prepareDeviceHostForLogin(DeviceItem device) async {
+    /// Returns the prepared host's path type together with the outcome, so the
+    /// endpoint sync that follows can record which kind of path won.
+    Future<({bool prepared, DevicePathType? pathType})> prepareDeviceHostForLogin(DeviceItem device) async {
       final dp = ref.read(deviceProvider.notifier);
       final rp = ref.read(remoteProvider.notifier);
       final detection = DeviceDetectionService(deviceProvider: dp, remoteProvider: rp);
@@ -783,7 +804,7 @@ class CuratorLoginForm extends HookConsumerWidget {
             login: email.value.trim(),
             devicePaths: dp.getCachedDevicePathsForDevice(seagateDeviceId)?.paths,
           );
-          return true;
+          return (prepared: true, pathType: ping.pathType);
         }
       }
 
@@ -798,11 +819,11 @@ class CuratorLoginForm extends HookConsumerWidget {
               ? null
               : dp.getCachedDevicePathsForDevice(seagateDeviceId)?.paths,
         );
-        return true;
+        return (prepared: true, pathType: device.pathType);
       }
 
       dp.clearDevice(save: true);
-      return false;
+      return (prepared: false, pathType: null);
     }
 
     bool isResetPasswordEnabled() =>
@@ -995,7 +1016,7 @@ class CuratorLoginForm extends HookConsumerWidget {
         }
 
         final preparedBeforeLogin = await prepareDeviceHostForLogin(selected);
-        if (!preparedBeforeLogin) {
+        if (!preparedBeforeLogin.prepared) {
           warningMessage.value = "login_form_server_error".tr();
           return;
         }
@@ -1006,7 +1027,11 @@ class CuratorLoginForm extends HookConsumerWidget {
           log.warning('[Login] Aborted: connected device host is null after prepareDeviceHostForLogin');
           return;
         }
-        final endpointSynced = await syncServerEndpointWithBaseUrl(baseUrl: connectedBaseUrl, flowTag: 'Login');
+        final endpointSynced = await syncServerEndpointWithBaseUrl(
+          baseUrl: connectedBaseUrl,
+          flowTag: 'Login',
+          pathType: preparedBeforeLogin.pathType,
+        );
         if (!endpointSynced) {
           return;
         }

--- a/mobile/test/services/network/recovery_executor_test.dart
+++ b/mobile/test/services/network/recovery_executor_test.dart
@@ -17,6 +17,25 @@ const _success = EndpointResolutionResult(
   selectionSource: 'test',
 );
 
+/// Endpoints as they actually look in the field: a LAN ip for the local path,
+/// the remote-access host for the cloud one.
+const _localEndpoint = 'https://192.168.1.16/photos/api';
+const _remoteEndpoint = 'https://57390a5d-1390-4ec9-9e2a-29690822241a.remote.lasea.fr/photos/api';
+
+const _localSuccess = EndpointResolutionResult(
+  success: true,
+  endpoint: _localEndpoint,
+  resolvedPathType: 'local',
+  selectionSource: 'remote_device_paths',
+);
+
+const _remoteSuccess = EndpointResolutionResult(
+  success: true,
+  endpoint: _remoteEndpoint,
+  resolvedPathType: 'remote',
+  selectionSource: 'remote_device_paths',
+);
+
 EndpointResolutionResult _failure(String reason) =>
     EndpointResolutionResult(success: false, reason: reason, selectionSource: 'test');
 
@@ -29,8 +48,12 @@ NetworkSnapshot _snap({
   bool otpModalShowing = false,
   bool isResolving = false,
   String? activeEndpoint = 'https://homecloud.local/photos/api',
+  String? cachedPathType = 'local',
   String? loginEmail = 'user@example.com',
   bool suppressFindingToast = false,
+  bool hasEstablishedConnectedThisLaunch = false,
+  String? networkIdentity,
+  String? lastConnectedNetworkIdentity,
 }) {
   return NetworkSnapshot(
     event: RecoveryEvent(trigger: trigger, suppressFindingToast: suppressFindingToast),
@@ -42,12 +65,19 @@ NetworkSnapshot _snap({
     seagateDeviceId: null,
     loginEmail: loginEmail,
     activeEndpoint: activeEndpoint,
-    cachedPathType: 'local',
+    cachedPathType: cachedPathType,
     transport: transport,
     isResolving: isResolving,
     otpModalShowing: otpModalShowing,
+    hasEstablishedConnectedThisLaunch: hasEstablishedConnectedThisLaunch,
+    networkIdentity: networkIdentity,
+    lastConnectedNetworkIdentity: lastConnectedNetworkIdentity,
   );
 }
+
+/// Network identity in the shape the monitor builds it.
+String _identity({String transport = 'wifi', String ssid = 'Home', String ip = '192.168.1.44'}) =>
+    'c:$transport|ssid:$ssid|ip:$ip';
 
 class FakeSnapshotBuilder implements SnapshotBuilder {
   FakeSnapshotBuilder(this.snapshot);
@@ -64,6 +94,12 @@ class FakeSnapshotBuilder implements SnapshotBuilder {
   bool isAppInForeground = true;
   @override
   String? cachedPathType;
+  @override
+  bool hasEstablishedConnectedThisLaunch = false;
+  @override
+  String? networkIdentity;
+  @override
+  String? lastConnectedNetworkIdentity;
 
   @override
   DeviceProvider get deviceProvider => throw UnimplementedError();
@@ -145,6 +181,10 @@ class FakeTriggerService implements PathResolveTriggerService {
 class RecordingCallbacks implements RecoveryExecutorCallbacks {
   final List<String> events = [];
   bool probeReachable = true;
+
+  /// When non-empty, successive [probeCachedEndpoint] calls consume these
+  /// before falling back to [probeReachable].
+  final List<bool> scriptedProbeResults = [];
   Future<void> Function()? otpRetry;
   PingResult? reconnectedWith;
 
@@ -169,6 +209,9 @@ class RecordingCallbacks implements RecoveryExecutorCallbacks {
   @override
   Future<bool> probeCachedEndpoint({required Duration timeout}) async {
     events.add('probe');
+    if (scriptedProbeResults.isNotEmpty) {
+      return scriptedProbeResults.removeAt(0);
+    }
     return probeReachable;
   }
 
@@ -227,6 +270,34 @@ void main() {
       expect(h.callbacks.events, ['probe', 'connected']);
       expect(h.triggers.calls, isEmpty);
       expect(h.executor.lastPlanDebugReason, 'cached_endpoint_reachable');
+    });
+
+    test('connectivity change with reachable cached endpoint skips resolve', () async {
+      // Airplane on/off: LAN IP answers while mDNS may still be empty.
+      final h = _harness(_snap(trigger: RecoveryTrigger.connectivityChange));
+      h.callbacks.probeReachable = true;
+
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.connectivityChange));
+
+      expect(h.callbacks.events, ['probe', 'connected']);
+      expect(h.triggers.calls, isEmpty);
+      expect(h.callbacks.events, isNot(contains('otp')));
+      expect(h.executor.lastPlanDebugReason, 'cached_endpoint_reachable');
+    });
+
+    test('resolve fail then cached endpoint recovers skips OTP', () async {
+      // Cheap probe misses, full resolve fails, but the LAN IP answers again
+      // before OTP — common right after airplane off.
+      final h = _harness(_snap(trigger: RecoveryTrigger.connectivityChange));
+      h.callbacks.scriptedProbeResults.addAll([false, true]);
+      h.triggers.results.add(_failure('no_available_path'));
+      h.triggers.results.add(_failure('no_available_path'));
+
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.connectivityChange));
+
+      expect(h.callbacks.events, isNot(contains('otp')));
+      expect(h.callbacks.events, contains('connected'));
+      expect(h.executor.lastPlanDebugReason, 'post_fail_cached_reachable');
     });
 
     test('app resume with dead cached endpoint falls back to full resolve', () async {
@@ -342,6 +413,37 @@ void main() {
       expect(h.executor.lastPlanDebugReason, 'post_fail_remote_auth_unable');
     });
 
+    test('cold-start api probe failure prompts OTP before first connect', () async {
+      final h = _harness(_snap(trigger: RecoveryTrigger.apiTransportError, activeEndpoint: null));
+      h.triggers.results.add(_failure('no_available_path'));
+      h.triggers.results.add(_failure('no_available_path'));
+
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.apiTransportError));
+
+      expect(h.callbacks.events, ['reconnectStarted:false', 'otp']);
+      expect(h.executor.lastPlanDebugReason, 'post_fail_prompt_otp');
+    });
+
+    test('mid-session automatic probe failure reports unable, never OTP', () async {
+      // A live local session (no remote auth) hitting a transient failure during
+      // sync must not pop the OTP modal — it surfaces "connection lost" instead.
+      final h = _harness(
+        _snap(
+          trigger: RecoveryTrigger.apiTransportError,
+          activeEndpoint: null,
+          hasEstablishedConnectedThisLaunch: true,
+        ),
+      );
+      h.triggers.results.add(_failure('no_available_path'));
+      h.triggers.results.add(_failure('no_available_path'));
+
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.apiTransportError));
+
+      expect(h.callbacks.events, isNot(contains('otp')));
+      expect(h.callbacks.events, ['reconnectStarted:false', 'failed']);
+      expect(h.executor.lastPlanDebugReason, 'post_fail_background_probe_unable');
+    });
+
     test('failure without login email reports unable', () async {
       final h = _harness(_snap(loginEmail: null, activeEndpoint: null));
       h.triggers.results.add(_failure('fallback_path_invalid'));
@@ -365,6 +467,136 @@ void main() {
       expect(h.callbacks.events, ['failed']);
       expect(h.triggers.calls, isEmpty);
       expect(h.executor.lastPlanDebugReason, 'transport_none');
+    });
+
+    test('REPRO wifi->wifi switch still prompts OTP after soft-local retry', () async {
+      // Field report: wifi1 (local device) -> wifi2 (hotspot, no device) via the
+      // system shade, no OTP modal on return. The soft-local retry re-enters
+      // _handleResolveResult with the same snapshot, so its failure signature
+      // equals the one the first pass just stored — it must not read as a
+      // duplicate connectivity failure and swallow the OTP prompt.
+      final h = _harness(_snap(trigger: RecoveryTrigger.connectivityChange));
+      h.callbacks.scriptedProbeResults.addAll([false, false]);
+      h.triggers.results.add(_failure('no_available_path'));
+      h.triggers.results.add(_failure('no_available_path'));
+
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.connectivityChange));
+
+      expect(h.callbacks.events, contains('otp'));
+      expect(h.executor.lastPlanDebugReason, 'post_fail_prompt_otp');
+    });
+
+    test('connectivity failure on the network that last connected reports unable', () async {
+      // HC or the router restarting on the same wifi: remote access is not the
+      // answer, the Retry banner is. Guards the "false OTP during local
+      // connection loss" regression that the in-run retry fix reopens.
+      final home = _identity();
+      final h = _harness(
+        _snap(
+          trigger: RecoveryTrigger.connectivityChange,
+          networkIdentity: home,
+          lastConnectedNetworkIdentity: home,
+          hasEstablishedConnectedThisLaunch: true,
+        ),
+      );
+      h.callbacks.scriptedProbeResults.addAll([false, false]);
+      h.triggers.results.add(_failure('no_available_path'));
+      h.triggers.results.add(_failure('no_available_path'));
+
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.connectivityChange));
+
+      expect(h.callbacks.events, isNot(contains('otp')));
+      expect(h.callbacks.events, contains('failed'));
+      expect(h.executor.lastPlanDebugReason, 'post_fail_same_network_outage_unable');
+    });
+
+    test('connectivity failure after switching networks still prompts OTP', () async {
+      final h = _harness(
+        _snap(
+          trigger: RecoveryTrigger.connectivityChange,
+          networkIdentity: _identity(ssid: 'Hotspot', ip: '10.167.63.119'),
+          lastConnectedNetworkIdentity: _identity(),
+          hasEstablishedConnectedThisLaunch: true,
+        ),
+      );
+      h.callbacks.scriptedProbeResults.addAll([false, false]);
+      h.triggers.results.add(_failure('no_available_path'));
+      h.triggers.results.add(_failure('no_available_path'));
+
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.connectivityChange));
+
+      expect(h.callbacks.events, contains('otp'));
+      expect(h.executor.lastPlanDebugReason, 'post_fail_prompt_otp');
+    });
+
+    test('uninformative network identity still prompts OTP', () async {
+      // iOS without location permission reports neither ssid nor ip: every
+      // network looks alike, so "same network" must not be concluded.
+      final blind = _identity(ssid: '-', ip: '-');
+      final h = _harness(
+        _snap(
+          trigger: RecoveryTrigger.connectivityChange,
+          networkIdentity: blind,
+          lastConnectedNetworkIdentity: blind,
+          hasEstablishedConnectedThisLaunch: true,
+        ),
+      );
+      h.callbacks.scriptedProbeResults.addAll([false, false]);
+      h.triggers.results.add(_failure('no_available_path'));
+      h.triggers.results.add(_failure('no_available_path'));
+
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.connectivityChange));
+
+      expect(h.callbacks.events, contains('otp'));
+      expect(h.executor.lastPlanDebugReason, 'post_fail_prompt_otp');
+    });
+
+    test('manual retry on the last connected network still reaches OTP', () async {
+      // The banner's Retry is the user asking for remote access explicitly.
+      final home = _identity();
+      final h = _harness(
+        _snap(
+          trigger: RecoveryTrigger.manualRetry,
+          networkIdentity: home,
+          lastConnectedNetworkIdentity: home,
+          hasEstablishedConnectedThisLaunch: true,
+        ),
+      );
+      h.callbacks.scriptedProbeResults.addAll([false, false]);
+      h.triggers.results.add(_failure('no_available_path'));
+      h.triggers.results.add(_failure('no_available_path'));
+
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.manualRetry));
+
+      expect(h.callbacks.events, contains('otp'));
+      expect(h.executor.lastPlanDebugReason, 'post_fail_prompt_otp');
+    });
+
+    test('same failure on a different network is not a duplicate', () async {
+      final h = _harness(
+        _snap(
+          trigger: RecoveryTrigger.connectivityChange,
+          loginEmail: null,
+          activeEndpoint: null,
+          networkIdentity: _identity(),
+        ),
+      );
+      h.triggers.results.add(_failure('fallback_path_invalid'));
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.connectivityChange));
+      expect(h.callbacks.events, ['reconnectStarted:true', 'failed']);
+
+      h.callbacks.events.clear();
+      h.builder.snapshot = _snap(
+        trigger: RecoveryTrigger.connectivityChange,
+        loginEmail: null,
+        activeEndpoint: null,
+        networkIdentity: _identity(ssid: 'Hotspot', ip: '10.167.63.119'),
+      );
+      h.triggers.results.add(_failure('fallback_path_invalid'));
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.connectivityChange));
+
+      expect(h.callbacks.events, ['reconnectStarted:true', 'failed']);
+      expect(h.executor.lastPlanDebugReason, 'post_fail_unable_no_email');
     });
 
     test('duplicate connectivity failure is suppressed silently', () async {
@@ -418,6 +650,7 @@ void main() {
         _snap(trigger: RecoveryTrigger.connectivityChange, transport: TransportKind.cellular),
         policy: noGrace,
       );
+      h.callbacks.probeReachable = false;
       // Second build (post-grace) reports wifi.
       h.builder.scriptedBuilds.add(
         _snap(trigger: RecoveryTrigger.connectivityChange, transport: TransportKind.cellular),
@@ -456,6 +689,423 @@ void main() {
     });
   });
 
+  // End-to-end matrix of the transitions the app is expected to survive. Each
+  // test names the transition, the path before it and the path expected after.
+  group('RecoveryExecutor network transition scenarios', () {
+    const noGrace = RecoveryPolicy(
+      offWifiOtpGraceDelay: Duration.zero,
+      transportSettleDelay: Duration.zero,
+    );
+
+    // --- wifi -> wifi -------------------------------------------------------
+
+    test('wifi->wifi: local becomes remote when the new network has no device', () async {
+      final h = _harness(
+        _snap(
+          trigger: RecoveryTrigger.connectivityChange,
+          activeEndpoint: _localEndpoint,
+          cachedPathType: 'local',
+          remoteAuth: true,
+          hasEstablishedConnectedThisLaunch: true,
+          networkIdentity: _identity(ssid: 'Hotspot', ip: '10.167.63.119'),
+          lastConnectedNetworkIdentity: _identity(),
+        ),
+      );
+      // The LAN ip is gone on the new network, so the cheap probe misses.
+      h.callbacks.probeReachable = false;
+      h.triggers.results.add(_remoteSuccess);
+
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.connectivityChange));
+
+      expect(h.callbacks.events, ['probe', 'reconnectStarted:true', 'connected', 'reconnected']);
+      expect(h.callbacks.reconnectedWith?.pathType?.value, 'remote');
+    });
+
+    test('wifi->wifi: local with no device and no remote session prompts OTP', () async {
+      final h = _harness(
+        _snap(
+          trigger: RecoveryTrigger.connectivityChange,
+          activeEndpoint: _localEndpoint,
+          cachedPathType: 'local',
+          hasEstablishedConnectedThisLaunch: true,
+          networkIdentity: _identity(ssid: 'Hotspot', ip: '10.167.63.119'),
+          lastConnectedNetworkIdentity: _identity(),
+        ),
+      );
+      h.callbacks.scriptedProbeResults.addAll([false, false]);
+      h.triggers.results.add(_failure('no_available_path'));
+      h.triggers.results.add(_failure('no_available_path'));
+
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.connectivityChange));
+
+      expect(h.callbacks.events, contains('otp'));
+      expect(h.executor.lastPlanDebugReason, 'post_fail_prompt_otp');
+    });
+
+    test('wifi->wifi: remote becomes local, cached remote endpoint never short-circuits', () async {
+      // REGRESSION: the reachable remote endpoint answers from any network, so
+      // a cheap probe here would skip the resolve and strand the app on remote.
+      final h = _harness(
+        _snap(
+          trigger: RecoveryTrigger.connectivityChange,
+          activeEndpoint: _remoteEndpoint,
+          cachedPathType: 'remote',
+          remoteAuth: true,
+          hasEstablishedConnectedThisLaunch: true,
+        ),
+      );
+      h.callbacks.probeReachable = true;
+      h.triggers.results.add(_localSuccess);
+
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.connectivityChange));
+
+      expect(h.callbacks.events, isNot(contains('probe')));
+      expect(h.callbacks.events, ['reconnectStarted:true', 'connected', 'reconnected']);
+      expect(h.callbacks.reconnectedWith?.pathType?.value, 'local');
+    });
+
+    test('wifi->wifi: remote endpoint picked at login (unknown path type) still resolves', () async {
+      // The resolver only learns the path type from its own resolves; a path
+      // chosen in the login form leaves cachedPathType null.
+      final h = _harness(
+        _snap(
+          trigger: RecoveryTrigger.connectivityChange,
+          activeEndpoint: _remoteEndpoint,
+          cachedPathType: null,
+          remoteAuth: true,
+          hasEstablishedConnectedThisLaunch: true,
+        ),
+      );
+      h.callbacks.probeReachable = true;
+      h.triggers.results.add(_localSuccess);
+
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.connectivityChange));
+
+      expect(h.callbacks.events, isNot(contains('probe')));
+      expect(h.callbacks.reconnectedWith?.pathType?.value, 'local');
+    });
+
+    test('wifi->wifi: same network flap keeps the cheap probe on a live LAN endpoint', () async {
+      // Counterpart to the two above: on a local endpoint the short-circuit is
+      // the point — it is what keeps a wifi flap from popping the OTP modal.
+      final home = _identity();
+      final h = _harness(
+        _snap(
+          trigger: RecoveryTrigger.connectivityChange,
+          activeEndpoint: _localEndpoint,
+          cachedPathType: 'local',
+          networkIdentity: home,
+          lastConnectedNetworkIdentity: home,
+          hasEstablishedConnectedThisLaunch: true,
+        ),
+      );
+      h.callbacks.probeReachable = true;
+
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.connectivityChange));
+
+      expect(h.callbacks.events, ['probe', 'connected']);
+      expect(h.triggers.calls, isEmpty);
+    });
+
+    test('wifi->wifi: OTP answered on the new network lands on remote', () async {
+      // Spec tail of the scenario above: the modal is only the way to get a
+      // remote session; answering it must finish on the remote path.
+      final h = _harness(
+        _snap(
+          trigger: RecoveryTrigger.connectivityChange,
+          activeEndpoint: _localEndpoint,
+          cachedPathType: 'local',
+          hasEstablishedConnectedThisLaunch: true,
+        ),
+      );
+      h.callbacks.scriptedProbeResults.addAll([false, false]);
+      h.triggers.results.add(_failure('no_available_path'));
+      h.triggers.results.add(_failure('no_available_path'));
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.connectivityChange));
+      expect(h.callbacks.otpRetry, isNotNull);
+
+      // OTP accepted: remote access is now authenticated.
+      h.builder.snapshot = _snap(
+        trigger: RecoveryTrigger.remoteAuthRetry,
+        activeEndpoint: _localEndpoint,
+        cachedPathType: 'local',
+        remoteAuth: true,
+        hasEstablishedConnectedThisLaunch: true,
+      );
+      h.triggers.results.add(_remoteSuccess);
+      await h.callbacks.otpRetry!();
+
+      expect(h.triggers.calls.last, 'networkChanged:remote_auth_retry');
+      expect(h.callbacks.reconnectedWith?.pathType?.value, 'remote');
+    });
+
+    test('wifi->cellular: OTP answered off wifi lands on remote', () async {
+      final h = _harness(
+        _snap(
+          trigger: RecoveryTrigger.connectivityChange,
+          transport: TransportKind.cellular,
+          activeEndpoint: _localEndpoint,
+          cachedPathType: 'local',
+          hasEstablishedConnectedThisLaunch: true,
+        ),
+        policy: noGrace,
+      );
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.connectivityChange));
+      expect(h.callbacks.events, ['otp']);
+
+      h.builder.snapshot = _snap(
+        trigger: RecoveryTrigger.remoteAuthRetry,
+        transport: TransportKind.cellular,
+        activeEndpoint: _localEndpoint,
+        cachedPathType: 'local',
+        remoteAuth: true,
+        hasEstablishedConnectedThisLaunch: true,
+      );
+      h.triggers.results.add(_remoteSuccess);
+      await h.callbacks.otpRetry!();
+
+      expect(h.executor.lastPlanDebugReason, 'off_wifi_remote_only');
+      expect(h.callbacks.reconnectedWith?.pathType?.value, 'remote');
+    });
+
+    // --- cellular -> wifi ---------------------------------------------------
+
+    test('cellular->wifi: switches to the local device', () async {
+      final h = _harness(
+        _snap(
+          trigger: RecoveryTrigger.connectivityChange,
+          transport: TransportKind.wifi,
+          activeEndpoint: _remoteEndpoint,
+          cachedPathType: 'remote',
+          remoteAuth: true,
+          hasEstablishedConnectedThisLaunch: true,
+        ),
+      );
+      h.callbacks.probeReachable = true;
+      h.triggers.results.add(_localSuccess);
+
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.connectivityChange));
+
+      expect(h.callbacks.events, isNot(contains('probe')));
+      expect(h.triggers.calls, ['networkChanged:connectivity_change']);
+      expect(h.callbacks.reconnectedWith?.pathType?.value, 'local');
+    });
+
+    test('cellular->wifi: no local device, stays on remote without OTP', () async {
+      final h = _harness(
+        _snap(
+          trigger: RecoveryTrigger.connectivityChange,
+          transport: TransportKind.wifi,
+          activeEndpoint: _remoteEndpoint,
+          cachedPathType: 'remote',
+          remoteAuth: true,
+          hasEstablishedConnectedThisLaunch: true,
+        ),
+      );
+      h.triggers.results.add(_remoteSuccess);
+
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.connectivityChange));
+
+      expect(h.callbacks.events, ['reconnectStarted:true', 'connected', 'reconnected']);
+      expect(h.callbacks.events, isNot(contains('otp')));
+      expect(h.callbacks.reconnectedWith?.pathType?.value, 'remote');
+    });
+
+    // --- wifi -> cellular ---------------------------------------------------
+
+    test('wifi->cellular: resolves remote-only with a remote session', () async {
+      final h = _harness(
+        _snap(
+          trigger: RecoveryTrigger.connectivityChange,
+          transport: TransportKind.cellular,
+          activeEndpoint: _localEndpoint,
+          cachedPathType: 'local',
+          remoteAuth: true,
+          hasEstablishedConnectedThisLaunch: true,
+        ),
+        policy: noGrace,
+      );
+      h.triggers.results.add(_remoteSuccess);
+
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.connectivityChange));
+
+      expect(h.executor.lastPlanDebugReason, 'off_wifi_remote_only');
+      expect(h.callbacks.events, ['reconnectStarted:true', 'connected', 'reconnected']);
+      expect(h.callbacks.reconnectedWith?.pathType?.value, 'remote');
+    });
+
+    test('wifi->cellular: already on remote stays on remote', () async {
+      // Remote-only login: nothing local to lose, the path must simply hold.
+      final h = _harness(
+        _snap(
+          trigger: RecoveryTrigger.connectivityChange,
+          transport: TransportKind.cellular,
+          activeEndpoint: _remoteEndpoint,
+          cachedPathType: 'remote',
+          remoteAuth: true,
+          hasEstablishedConnectedThisLaunch: true,
+        ),
+        policy: noGrace,
+      );
+      h.triggers.results.add(_remoteSuccess);
+
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.connectivityChange));
+
+      expect(h.executor.lastPlanDebugReason, 'off_wifi_remote_only');
+      expect(h.callbacks.events, isNot(contains('otp')));
+      expect(h.callbacks.reconnectedWith?.pathType?.value, 'remote');
+    });
+
+    test('wifi->cellular: without a remote session prompts OTP', () async {
+      final h = _harness(
+        _snap(
+          trigger: RecoveryTrigger.connectivityChange,
+          transport: TransportKind.cellular,
+          activeEndpoint: _localEndpoint,
+          cachedPathType: 'local',
+          hasEstablishedConnectedThisLaunch: true,
+        ),
+        policy: noGrace,
+      );
+
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.connectivityChange));
+
+      expect(h.callbacks.events, ['otp']);
+      expect(h.triggers.calls, isEmpty);
+    });
+
+    // --- airplane / no transport -> ... -------------------------------------
+
+    test('off->wifi: reports offline, then reconnects to the local device', () async {
+      final h = _harness(
+        _snap(
+          trigger: RecoveryTrigger.connectivityChange,
+          transport: TransportKind.none,
+          activeEndpoint: _localEndpoint,
+          cachedPathType: 'local',
+          hasEstablishedConnectedThisLaunch: true,
+        ),
+        policy: noGrace,
+      );
+
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.connectivityChange));
+      expect(h.callbacks.events, ['failed']);
+      expect(h.executor.lastPlanDebugReason, 'transport_none');
+
+      // Wifi comes back: the LAN endpoint is not answering yet (mDNS still
+      // empty too), so the resolve is what brings local back.
+      h.callbacks.events.clear();
+      h.builder.snapshot = _snap(
+        trigger: RecoveryTrigger.connectivityChange,
+        transport: TransportKind.wifi,
+        activeEndpoint: _localEndpoint,
+        cachedPathType: 'local',
+        hasEstablishedConnectedThisLaunch: true,
+      );
+      h.callbacks.probeReachable = false;
+      h.triggers.results.add(_localSuccess);
+
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.connectivityChange));
+
+      expect(h.callbacks.events, ['probe', 'reconnectStarted:true', 'connected', 'reconnected']);
+      expect(h.callbacks.reconnectedWith?.pathType?.value, 'local');
+    });
+
+    test('off->wifi: live LAN endpoint reconnects on the probe alone', () async {
+      final h = _harness(
+        _snap(
+          trigger: RecoveryTrigger.connectivityChange,
+          activeEndpoint: _localEndpoint,
+          cachedPathType: 'local',
+          hasEstablishedConnectedThisLaunch: true,
+        ),
+        policy: noGrace,
+      );
+      h.callbacks.probeReachable = true;
+
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.connectivityChange));
+
+      expect(h.callbacks.events, ['probe', 'connected']);
+      expect(h.triggers.calls, isEmpty);
+    });
+
+    test('off->cellular: no local device, connects remote', () async {
+      final h = _harness(
+        _snap(
+          trigger: RecoveryTrigger.connectivityChange,
+          transport: TransportKind.none,
+          activeEndpoint: _localEndpoint,
+          cachedPathType: 'local',
+          remoteAuth: true,
+          hasEstablishedConnectedThisLaunch: true,
+        ),
+        policy: noGrace,
+      );
+
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.connectivityChange));
+      expect(h.callbacks.events, ['failed']);
+
+      h.callbacks.events.clear();
+      h.builder.snapshot = _snap(
+        trigger: RecoveryTrigger.connectivityChange,
+        transport: TransportKind.cellular,
+        activeEndpoint: _localEndpoint,
+        cachedPathType: 'local',
+        remoteAuth: true,
+        hasEstablishedConnectedThisLaunch: true,
+      );
+      h.triggers.results.add(_remoteSuccess);
+
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.connectivityChange));
+
+      expect(h.executor.lastPlanDebugReason, 'off_wifi_remote_only');
+      expect(h.callbacks.reconnectedWith?.pathType?.value, 'remote');
+    });
+
+    // --- resume after a switch that happened while backgrounded -------------
+
+    test('resume on wifi with a cached remote endpoint searches for local', () async {
+      // The OS defers connectivity events while backgrounded, so the switch is
+      // observed as an appResume — it must search for local just the same.
+      final h = _harness(
+        _snap(
+          trigger: RecoveryTrigger.appResume,
+          activeEndpoint: _remoteEndpoint,
+          cachedPathType: null,
+          remoteAuth: true,
+          hasEstablishedConnectedThisLaunch: true,
+        ),
+      );
+      h.callbacks.probeReachable = true;
+      h.triggers.results.add(_localSuccess);
+
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.appResume));
+
+      expect(h.callbacks.events, isNot(contains('probe')));
+      expect(h.triggers.calls, ['networkChanged:app_resume']);
+      expect(h.callbacks.reconnectedWith?.pathType?.value, 'local');
+    });
+
+    test('api error on a cached remote endpoint searches for local', () async {
+      final h = _harness(
+        _snap(
+          trigger: RecoveryTrigger.apiTransportError,
+          activeEndpoint: _remoteEndpoint,
+          cachedPathType: null,
+          remoteAuth: true,
+          hasEstablishedConnectedThisLaunch: true,
+        ),
+      );
+      h.callbacks.probeReachable = true;
+      h.triggers.results.add(_localSuccess);
+
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.apiTransportError));
+
+      expect(h.callbacks.events, isNot(contains('probe')));
+      expect(h.triggers.calls, ['apiError:api_error']);
+    });
+  });
+
   group('RecoveryExecutor finding-toast surfacing', () {
     test('reachable cached endpoint never announces a reconnect', () async {
       // The monitor surfaces "finding network" from onReconnectStarted, so a
@@ -476,6 +1126,22 @@ void main() {
 
       await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.apiTransportError));
 
+      expect(h.callbacks.events, contains('reconnectStarted:false'));
+      expect(h.callbacks.reconnectStartedSuppressedFinding, isFalse);
+    });
+
+    test('health probe miss skips the redundant probe and announces immediately', () async {
+      // The health probe already found the endpoint unreachable, so recovery
+      // must not re-probe it (which would delay the toast by another timeout)
+      // and must announce the reconnect right away — even if a stray probe
+      // would have reported the cached endpoint reachable.
+      final h = _harness(_snap(trigger: RecoveryTrigger.healthProbeMiss));
+      h.callbacks.probeReachable = true;
+      h.triggers.results.add(_success);
+
+      await h.executor.run(const RecoveryEvent(trigger: RecoveryTrigger.healthProbeMiss));
+
+      expect(h.callbacks.events, isNot(contains('probe')));
       expect(h.callbacks.events, contains('reconnectStarted:false'));
       expect(h.callbacks.reconnectStartedSuppressedFinding, isFalse);
     });

--- a/mobile/test/services/network/recovery_policy_table_test.dart
+++ b/mobile/test/services/network/recovery_policy_table_test.dart
@@ -62,7 +62,7 @@ void main() {
     (
       name: 'connectivity change while OTP modal is up still proceeds',
       snapshot: _snap(trigger: RecoveryTrigger.connectivityChange, otpModalShowing: true),
-      reason: 'local_first_resolve_all',
+      reason: 'local_first_cheap_probe',
     ),
     (
       name: 'another resolve already active',
@@ -114,9 +114,11 @@ void main() {
       reason: 'local_first_cheap_probe',
     ),
     (
-      name: 'app resume with cached endpoint of unknown path type',
+      // Unknown is never assumed local: a remote endpoint answers from any
+      // network, so short-circuiting on one would strand the app on remote.
+      name: 'app resume with cached endpoint of unknown path type resolves fully',
       snapshot: _snap(trigger: RecoveryTrigger.appResume, cachedPathType: null),
-      reason: 'local_first_cheap_probe',
+      reason: 'local_first_resolve_all',
     ),
     (
       name: 'app resume on wifi with cached remote endpoint searches for local',
@@ -144,9 +146,11 @@ void main() {
       reason: 'local_first_cheap_probe',
     ),
     (
+      // The periodic health probe already found the endpoint unreachable, so
+      // recovery resolves immediately instead of re-probing the cached one.
       name: 'health probe miss with cached endpoint',
       snapshot: _snap(trigger: RecoveryTrigger.healthProbeMiss),
-      reason: 'local_first_cheap_probe',
+      reason: 'local_first_resolve_all',
     ),
     (
       name: 'manual retry with cached endpoint',
@@ -154,8 +158,24 @@ void main() {
       reason: 'local_first_cheap_probe',
     ),
     (
-      name: 'connectivity change goes straight to full resolve',
+      name: 'connectivity change with cached local endpoint cheap-probes first',
       snapshot: _snap(trigger: RecoveryTrigger.connectivityChange),
+      reason: 'local_first_cheap_probe',
+    ),
+    (
+      // Joining the home wifi on a cached remote endpoint must search for the
+      // local path — the remote one answers here too and would never yield.
+      name: 'connectivity change with cached remote endpoint searches for local',
+      snapshot: _snap(
+        trigger: RecoveryTrigger.connectivityChange,
+        cachedPathType: 'remote',
+        activeEndpoint: 'https://57390a5d.remote.lasea.fr/photos/api',
+      ),
+      reason: 'local_first_resolve_all',
+    ),
+    (
+      name: 'connectivity change without cached endpoint resolves fully',
+      snapshot: _snap(trigger: RecoveryTrigger.connectivityChange, activeEndpoint: null),
       reason: 'local_first_resolve_all',
     ),
     (

--- a/mobile/test/services/network/recovery_policy_test.dart
+++ b/mobile/test/services/network/recovery_policy_test.dart
@@ -121,16 +121,21 @@ void main() {
       expect((decision as ResolvePaths).cheapProbeFirst, isTrue);
     });
 
-    test('connectivityChange → full resolve without cheap probe', () {
+    test('connectivityChange on wifi with endpoint → cheap probe', () {
+      // Airplane / wifi flaps: same LAN IP is often reachable before mDNS is.
       final decision = policy.decide(_snap(trigger: RecoveryTrigger.connectivityChange));
-      final resolve = decision as ResolvePaths;
-      expect(resolve.cheapProbeFirst, isFalse);
-      expect(resolve.probeMode, PathProbeMode.all);
+      expect(decision.reason, 'local_first_cheap_probe');
+      expect((decision as ResolvePaths).cheapProbeFirst, isTrue);
     });
 
-    test('healthProbeMiss → cheap probe', () {
+    test('healthProbeMiss → full resolve without cheap probe', () {
+      // The periodic health probe already confirmed the active endpoint is
+      // unreachable, so recovery skips the redundant second probe and resolves
+      // immediately (surfacing the "finding network" toast right away).
       final decision = policy.decide(_snap(trigger: RecoveryTrigger.healthProbeMiss));
-      expect((decision as ResolvePaths).cheapProbeFirst, isTrue);
+      final resolve = decision as ResolvePaths;
+      expect(resolve.cheapProbeFirst, isFalse);
+      expect(resolve.reason, 'local_first_resolve_all');
     });
   });
 

--- a/mobile/test/services/network/resolve_trigger_service_test.dart
+++ b/mobile/test/services/network/resolve_trigger_service_test.dart
@@ -6,6 +6,7 @@
 import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hc_device/api/remote_access.enums.swagger.dart' show DevicePathType;
 import 'package:hc_device/hc_device.dart';
 import 'package:immich_mobile/services/network/endpoint_resolver.dart';
 
@@ -29,6 +30,9 @@ class FakeEndpointResolver implements HcDeviceEndpointResolver {
 
   @override
   String? getAvailablePathType() => null;
+
+  @override
+  Future<void> noteSelectedPath(String endpoint, {DevicePathType? pathType}) async {}
 
   @override
   List getDevicePaths(String remoteDeviceId) => const [];


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have carefully read CONTRIBUTING.md
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
