### PR TITLE
[HCNOVEO-1823] iOS: Spurious network change detection triggers unexpected OTP request during initial sync

### DIFF
--- a/mobile/hc_device/lib/services/device_detection_service.dart
+++ b/mobile/hc_device/lib/services/device_detection_service.dart
@@ -473,10 +473,13 @@ class DeviceDetectionService {
     PathProbeMode pathProbeMode = PathProbeMode.all,
     FutureOr<void> Function(PingResult betterResult)? onHigherPriorityPathResolved,
   }) async {
-    if (pathProbeMode == PathProbeMode.all && device != null && device.baseUrl != null) {
+    if (pathProbeMode == PathProbeMode.all &&
+        device != null &&
+        device.baseUrl != null &&
+        device.pathType != null) {
       final result = await _testPath(
         DevicePath(
-          type: DevicePathType.local,
+          type: device.pathType!,
           address: device.baseUrl!.host,
           port: device.baseUrl!.port,
         ),

--- a/mobile/lib/providers/auth.provider.dart
+++ b/mobile/lib/providers/auth.provider.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter_udid/flutter_udid.dart';
+import 'package:hc_device/api/remote_access.enums.swagger.dart' show DevicePathType;
 import 'package:hc_device/hc_device.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/constants.dart';
@@ -66,8 +67,8 @@ class AuthNotifier extends StateNotifier<AuthState> {
         ),
       );
 
-  Future<String> validateServerUrl(String url) {
-    return _authService.validateServerUrl(url);
+  Future<String> validateServerUrl(String url, {DevicePathType? pathType}) {
+    return _authService.validateServerUrl(url, pathType: pathType);
   }
 
   Future<LoginResponse> login(String email, String password) async {

--- a/mobile/lib/services/auth.service.dart
+++ b/mobile/lib/services/auth.service.dart
@@ -19,6 +19,7 @@ import 'package:immich_mobile/infrastructure/repositories/network.repository.dar
 import 'package:immich_mobile/services/api.service.dart';
 import 'package:immich_mobile/services/app_settings.service.dart';
 import 'package:immich_mobile/services/device_endpoint_utils.dart';
+import 'package:immich_mobile/services/network/endpoint_resolver.dart';
 import 'package:logging/logging.dart';
 
 final authServiceProvider = Provider(
@@ -29,6 +30,10 @@ final authServiceProvider = Provider(
     ref.watch(backgroundSyncProvider),
     ref.watch(appSettingsServiceProvider),
     ref.watch(hcPathResolverProvider),
+    HcDeviceEndpointResolver(
+      ref.watch(apiServiceProvider),
+      ref.watch(hcPathResolverProvider),
+    ),
     ref.read(deviceProvider.notifier),
   ),
 );
@@ -40,6 +45,7 @@ class AuthService {
   final BackgroundSyncManager _backgroundSyncManager;
   final AppSettingsService _appSettingsService;
   final HcPathResolver _hcPathResolver;
+  final HcDeviceEndpointResolver _endpointResolver;
   final DeviceProvider _deviceProvider;
   final _log = Logger("AuthService");
 
@@ -50,6 +56,7 @@ class AuthService {
     this._backgroundSyncManager,
     this._appSettingsService,
     this._hcPathResolver,
+    this._endpointResolver,
     this._deviceProvider,
   );
 
@@ -61,8 +68,8 @@ class AuthService {
   /// Returns the validated and resolved server URL as a [String].
   ///
   /// Throws an exception if the URL cannot be resolved or set.
-  Future<String> validateServerUrl(String url) async {
-    final validUrl = await _apiService.resolveAndSetEndpoint(url);
+  Future<String> validateServerUrl(String url, {DevicePathType? pathType}) async {
+    final validUrl = await _endpointResolver.resolveAndSetEndpointWithPathType(url, pathType: pathType);
     await _apiService.setDeviceInfoHeader();
     // Store.put(StoreKey.serverUrl, validUrl);
 
@@ -177,6 +184,7 @@ class AuthService {
     await _hcPathResolver.init();
     final resolved = await _apiService.activateFirstReachable(_availablePathCandidates());
     if (resolved != null) {
+      await _hcPathResolver.setAvailablePath(resolved);
       _log.info('[EndpointSwitch] activated trigger=$trigger endpoint=$resolved');
     }
     return resolved;

--- a/mobile/lib/services/network/endpoint_resolver.dart
+++ b/mobile/lib/services/network/endpoint_resolver.dart
@@ -119,6 +119,23 @@ class HcDeviceEndpointResolver {
   String? getAvailablePath() => _resolver.getAvailablePath();
   String? getAvailablePathType() => _resolver.availablePathType;
 
+  /// Single writer for endpoint + path type.
+  Future<String> resolveAndSetEndpointWithPathType(
+    String serverUrl, {
+    DevicePathType? pathType,
+    EndpointResolvePolicy policy = EndpointResolvePolicy.conservative,
+    bool pathAlreadyProbed = false,
+  }) async {
+    final resolvedEndpoint = await _apiService.resolveAndSetEndpoint(
+      serverUrl,
+      policy: policy,
+      pathAlreadyProbed: pathAlreadyProbed,
+    );
+    final resolvedPathType = HcPathType.fromDevicePathType(pathType);
+    await _resolver.setAvailablePath(resolvedEndpoint, pathType: resolvedPathType);
+    return resolvedEndpoint;
+  }
+
   /// Records the type of a path selected outside a resolve (login probes paths
   /// itself), so recovery can trust it: a local cached path may cheap-probe
   /// past a resolve, a remote one must not.

--- a/mobile/lib/widgets/forms/login/curator_login_form.dart
+++ b/mobile/lib/widgets/forms/login/curator_login_form.dart
@@ -18,7 +18,6 @@ import 'package:immich_mobile/providers/backup/backup.provider.dart';
 import 'package:immich_mobile/providers/developer_options.provider.dart';
 import 'package:immich_mobile/providers/device_path_refresh.provider.dart';
 import 'package:immich_mobile/providers/gallery_permission.provider.dart';
-import 'package:immich_mobile/providers/network/network_monitor.provider.dart';
 import 'package:immich_mobile/providers/server_info.provider.dart';
 import 'package:immich_mobile/providers/websocket.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
@@ -531,10 +530,7 @@ class CuratorLoginForm extends HookConsumerWidget {
       }
 
       try {
-        final resolvedServerUrl = await ref.read(authProvider.notifier).validateServerUrl(normalizedServerUrl);
-        // Login picks the path itself; record its type so recovery does not
-        // have to re-resolve to learn it (see noteSelectedPath).
-        await ref.read(hcDeviceEndpointResolverProvider).noteSelectedPath(resolvedServerUrl, pathType: pathType);
+        await ref.read(authProvider.notifier).validateServerUrl(normalizedServerUrl, pathType: pathType);
         log.info(
           '[$flowTag] Endpoint synced to selected device: $normalizedServerUrl '
           'pathType=${pathType?.value ?? '-'}',
@@ -1030,7 +1026,7 @@ class CuratorLoginForm extends HookConsumerWidget {
         final endpointSynced = await syncServerEndpointWithBaseUrl(
           baseUrl: connectedBaseUrl,
           flowTag: 'Login',
-          pathType: preparedBeforeLogin.pathType,
+          pathType: null,
         );
         if (!endpointSynced) {
           return;


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes # (issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

<details><summary><h2>Screenshots (if appropriate)</h2></summary>

<!-- Images go below this line. -->

</details>

<!-- API endpoint changes (if relevant)
## API Changes
The `/api/something` endpoint is now `/api/something-else`
-->

## Checklist:

- [ ] I have carefully read CONTRIBUTING.md
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if applicable
- [ ] I have no unrelated changes in the PR.
- [ ] I have confirmed that any new dependencies are strictly necessary.
- [ ] I have written tests for new code (if applicable)
- [ ] I have followed naming conventions/patterns in the surrounding code
- [ ] All code in `src/services/` uses repositories implementations for database calls, filesystem operations, etc.
- [ ] All code in `src/repositories/` is pretty basic/simple and does not have any immich specific logic (that belongs in `src/services/`)

## Please describe to which degree, if any, an LLM was used in creating this pull request.

...
